### PR TITLE
Implement and test validated/transformed casts

### DIFF
--- a/grassroots-backend/package-lock.json
+++ b/grassroots-backend/package-lock.json
@@ -22,6 +22,7 @@
         "pg": "^8.15.5",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "tstyche": "^3.5.0",
         "typeorm": "^0.3.22"
       },
       "devDependencies": {
@@ -32,7 +33,7 @@
         "@swc/core": "^1.10.7",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.10.7",
+        "@types/node": "^22.15.3",
         "@types/supertest": "^6.0.2",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
@@ -3019,6 +3020,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -3043,10 +3045,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -9945,6 +9948,29 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tstyche": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.5.0.tgz",
+      "integrity": "sha512-N4SUp/ZWaMGEcglpVFIzKez0GQEiBdfFDgcnqwv9O1mePZgos8N1cZCzNgGtPGo/w0ym04MjJcDnsw1sorEzgA==",
+      "license": "MIT",
+      "bin": {
+        "tstyche": "build/bin.js"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/tstyche/tstyche?sponsor=1"
+      },
+      "peerDependencies": {
+        "typescript": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/grassroots-backend/package.json
+++ b/grassroots-backend/package.json
@@ -11,7 +11,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "test": "jest -i",
+    "test": "jest -i && npx tstyche",
     "test:watch": "jest -i --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -31,6 +31,7 @@
     "pg": "^8.15.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "tstyche": "^3.5.0",
     "typeorm": "^0.3.22"
   },
   "devDependencies": {

--- a/grassroots-backend/src/grassroots-shared/cast.ts
+++ b/grassroots-backend/src/grassroots-shared/cast.ts
@@ -1,0 +1,43 @@
+import { ClassConstructor, plainToInstance } from "class-transformer";
+import { validateSync } from "class-validator";
+
+// Needs to be imported somewhere for `enableImplicitConversion` to work.
+import "reflect-metadata";
+
+// Roughly, given a class, gives you an interface with its attributes.
+export type PropsOf<T> = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  [K in keyof T as T[K] extends Function ? never : K]: T[K];
+};
+
+// Roughly, given a class, gives you an interface with the same attributes, but all untyped.
+export type PropsOfAsUnknown<T> = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  [K in keyof T as T[K] extends Function ? never : K]: unknown;
+};
+
+export function cast<T extends object>(
+  cls: ClassConstructor<T>,
+  plain: PropsOf<T>,
+): T {
+  const instance = plainToInstance(cls, plain);
+  const validationErrors = validateSync(instance);
+  if (validationErrors.length > 0) {
+    throw new Error(validationErrors.join("\n"));
+  }
+  return instance;
+}
+
+export function castWithConversion<T extends object>(
+  cls: ClassConstructor<T>,
+  plain: PropsOfAsUnknown<T>,
+): T {
+  const instance = plainToInstance(cls, plain, {
+    enableImplicitConversion: true,
+  });
+  const validationErrors = validateSync(instance);
+  if (validationErrors.length > 0) {
+    throw new Error(validationErrors.join("\n"));
+  }
+  return instance;
+}

--- a/grassroots-backend/src/testing/cast.spec.ts
+++ b/grassroots-backend/src/testing/cast.spec.ts
@@ -1,0 +1,33 @@
+import { IsNumber, Min } from "class-validator";
+import { cast, castWithConversion } from "../grassroots-shared/cast";
+
+class Test {
+  @IsNumber()
+  @Min(0)
+  a!: number;
+
+  constructor(a: number) {
+    this.a = a;
+  }
+}
+
+describe("cast", () => {
+  it("should cast in the trival case", () => {
+    expect(cast(Test, { a: 2 })).toEqual(new Test(2));
+  });
+
+  it("should be able to fail validation", () => {
+    expect(() => cast(Test, { a: -3 })).toThrow(Error);
+  });
+});
+
+describe("castWithConversion", () => {
+  it("Type converting cast works", () => {
+    const testCasted = castWithConversion(Test, { a: "2" });
+    expect(testCasted).toEqual(new Test(2));
+  });
+
+  it("Type converting cast can fail validation", () => {
+    expect(() => castWithConversion(Test, { a: "-2" })).toThrow(Error);
+  });
+});

--- a/grassroots-backend/src/testing/typetests/cast.test.ts
+++ b/grassroots-backend/src/testing/typetests/cast.test.ts
@@ -1,0 +1,39 @@
+import * as tstyche from "tstyche";
+import { cast, castWithConversion } from "../../grassroots-shared/cast";
+import { IsNumber, Min } from "class-validator";
+
+class Test {
+  @IsNumber()
+  @Min(0)
+  a!: number;
+
+  constructor(a: number) {
+    this.a = a;
+  }
+}
+
+describe("cast", () => {
+  it("should cast in the trivial case", () => {
+    const testCasted = cast(Test, { a: 2 });
+    tstyche.expect(testCasted).type.toBe<Test>();
+  });
+
+  it("should throw a type error if the properties don't overlap", () => {
+    tstyche
+      .expect(cast(Test, { b: 3 }))
+      .type.toRaiseError("does not exist in type");
+  });
+
+  it("should throw a type error if the types don't overlap", () => {
+    tstyche
+      .expect(cast(Test, { a: "2" }))
+      .type.toRaiseError("is not assignable to type");
+  });
+});
+
+describe("castWithConversion", () => {
+  it("Type converting cast works", () => {
+    const testCasted = castWithConversion(Test, { a: "2" });
+    tstyche.expect(testCasted).type.toBe<Test>();
+  });
+});

--- a/grassroots-backend/src/testing/typetests/tsconfig.json
+++ b/grassroots-backend/src/testing/typetests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["**test.ts"],
+  "exclude": []
+}

--- a/grassroots-backend/tsconfig.json
+++ b/grassroots-backend/tsconfig.json
@@ -13,5 +13,6 @@
     "outDir": "./dist",
     "incremental": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["src/testing/typetests/**"]
 }

--- a/grassroots-backend/tstyche.config.json
+++ b/grassroots-backend/tstyche.config.json
@@ -1,0 +1,3 @@
+{
+  "testFileMatch": ["**/typetests/**/*.test.ts"]
+}


### PR DESCRIPTION
To use class-validator and class-transformer in frontend code, we need a way to take a set of inputs (.e.g., form fields) and apply class-validator / class-transformer to create an instance of the appropriate class.

This PR supplies two such methods, one which assumes the inputs are of the appropriate type, and the other of which magically converts the inputs the the right type, (e.g., magically applying `parseInt` if needed.