### PR TITLE
Get rid of implicit type conversions

### DIFF
--- a/grassroots-backend/src/contacts/Contacts.service.ts
+++ b/grassroots-backend/src/contacts/Contacts.service.ts
@@ -54,7 +54,7 @@ export class ContactsService {
         lastName: LikeOrUndefined(contact.lastName),
         email: LikeOrUndefined(contact.email),
         phoneNumber: LikeOrUndefined(contact.phoneNumber),
-        id: contact.id ? Equal(contact.id) : undefined,
+        id: contact.id !== undefined ? Equal(contact.id) : undefined,
       },
     });
     return {

--- a/grassroots-backend/src/grassroots-shared/Cast.ts
+++ b/grassroots-backend/src/grassroots-shared/Cast.ts
@@ -10,32 +10,11 @@ export type PropsOf<T> = {
   [K in keyof T as T[K] extends Function ? never : K]: T[K];
 };
 
-// Roughly, given a class, gives you an interface with the same attributes, but all untyped.
-export type PropsOfAsUnknown<T> = {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  [K in keyof T as T[K] extends Function ? never : K]: unknown;
-};
-
 export function cast<T extends object>(
   cls: ClassConstructor<T>,
   plain: PropsOf<T>,
 ): T {
   const instance = plainToInstance(cls, plain);
-  const validationErrors = validateSync(instance);
-  if (validationErrors.length > 0) {
-    throw new Error(validationErrors.join("\n"));
-  }
-  return instance;
-}
-
-export function castWithConversion<T extends object>(
-  cls: ClassConstructor<T>,
-  plain: PropsOfAsUnknown<T>,
-): T {
-  const instance = plainToInstance(cls, plain, {
-    enableImplicitConversion: true,
-  });
-
   const validationErrors = validateSync(instance);
   if (validationErrors.length > 0) {
     throw new Error(validationErrors.join("\n"));

--- a/grassroots-backend/src/grassroots-shared/Cast.ts
+++ b/grassroots-backend/src/grassroots-shared/Cast.ts
@@ -1,9 +1,6 @@
 import { ClassConstructor, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-// Needs to be imported somewhere for `enableImplicitConversion` to work.
-import "reflect-metadata";
-
 // Roughly, given a class, gives you an interface with its attributes.
 export type PropsOf<T> = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type

--- a/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
+++ b/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
@@ -34,7 +34,7 @@ export class CreateBulkContactResponseDTO {
 export class ContactEntityOutDTO {
   @PrimaryGeneratedColumn()
   @IsInt()
-  @Min(0)
+  @Min(1)
   id!: number;
 
   @Column()
@@ -65,7 +65,7 @@ export class ContactSearchInDTO {
     value === "" ? undefined : Number(value),
   )
   @IsInt()
-  @Min(0)
+  @Min(1)
   id?: number;
   email?: string;
   firstName?: string;

--- a/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
+++ b/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
@@ -9,6 +9,7 @@ import {
 } from "class-validator";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 import { PaginatedInDTO, PaginatedOutDTO } from "./Paginated.dto";
+import { Transform } from "class-transformer";
 
 export class CreateContactInDto {
   @IsEmail()
@@ -60,6 +61,9 @@ export class GetContactByIDResponse {
 
 export class ContactSearchInDTO {
   @IsOptional()
+  @Transform(({ value }: { value: string }) =>
+    value === "" ? undefined : Number(value),
+  )
   @IsInt()
   @Min(0)
   id?: number;

--- a/grassroots-backend/src/metadata.ts
+++ b/grassroots-backend/src/metadata.ts
@@ -51,7 +51,7 @@ export default async () => {
               ids: { required: true, type: () => [Number] },
             },
             ContactEntityOutDTO: {
-              id: { required: true, type: () => Number, minimum: 0 },
+              id: { required: true, type: () => Number, minimum: 1 },
               email: { required: true, type: () => String, format: "email" },
               firstName: { required: true, type: () => String },
               lastName: { required: true, type: () => String },
@@ -67,7 +67,7 @@ export default async () => {
               },
             },
             ContactSearchInDTO: {
-              id: { required: false, type: () => Number, minimum: 0 },
+              id: { required: false, type: () => Number, minimum: 1 },
               email: { required: false, type: () => String },
               firstName: { required: false, type: () => String },
               lastName: { required: false, type: () => String },

--- a/grassroots-backend/src/testing/Cast.spec.ts
+++ b/grassroots-backend/src/testing/Cast.spec.ts
@@ -1,5 +1,5 @@
 import { IsNumber, Min } from "class-validator";
-import { cast, castWithConversion } from "../grassroots-shared/Cast";
+import { cast } from "../grassroots-shared/Cast";
 
 class Test {
   @IsNumber()
@@ -18,16 +18,5 @@ describe("cast", () => {
 
   it("should be able to fail validation", () => {
     expect(() => cast(Test, { a: -3 })).toThrow(Error);
-  });
-});
-
-describe("castWithConversion", () => {
-  it("Type converting cast works", () => {
-    const testCasted = castWithConversion(Test, { a: "2" });
-    expect(testCasted).toEqual(new Test(2));
-  });
-
-  it("Type converting cast can fail validation", () => {
-    expect(() => castWithConversion(Test, { a: "-2" })).toThrow(Error);
   });
 });

--- a/grassroots-backend/src/testing/typetests/Cast.test.ts
+++ b/grassroots-backend/src/testing/typetests/Cast.test.ts
@@ -1,5 +1,5 @@
 import * as tstyche from "tstyche";
-import { cast, castWithConversion } from "../../grassroots-shared/Cast";
+import { cast } from "../../grassroots-shared/Cast";
 import { IsNumber, Min } from "class-validator";
 
 class Test {
@@ -28,12 +28,5 @@ describe("cast", () => {
     tstyche
       .expect(cast(Test, { a: "2" }))
       .type.toRaiseError("is not assignable to type");
-  });
-});
-
-describe("castWithConversion", () => {
-  it("Type converting cast works", () => {
-    const testCasted = castWithConversion(Test, { a: "2" });
-    tstyche.expect(testCasted).type.toBe<Test>();
   });
 });

--- a/grassroots-frontend/src/routes/SharedSearch.tsx
+++ b/grassroots-frontend/src/routes/SharedSearch.tsx
@@ -2,14 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { JSX, useState } from "react";
 import { useContactSearch } from "../hooks/useContactSearch";
 import { PaginatedContacts } from "../components/PaginatedContacts";
-import { castWithConversion } from "../grassroots-shared/Cast";
+import { cast } from "../grassroots-shared/Cast";
 import { ContactSearchInDTO } from "../grassroots-shared/Contact.entity.dto";
 
 export const Route = createFileRoute("/SharedSearch")({
   component: SharedSearch,
   validateSearch: (search: Record<string, unknown>): ContactSearchInDTO => {
-    search.id = search.id == "" ? undefined : search.id;
-    return castWithConversion(ContactSearchInDTO, search);
+    return cast(ContactSearchInDTO, search);
   },
 });
 


### PR DESCRIPTION
The class-transformer [docs](https://github.com/typestack/class-transformer?tab=readme-ov-file#implicit-type-conversion) on implicit conversion say: 

    NOTE If you use class-validator together with class-transformer 
    you propably DON'T want to enable this function.

There's apparently a bunch of bad behavior where "false" will end up true, and stuff like that.

Instead, we should define explicit mechanisms for converting between types where appropriate. This lets us centralize specific special transforms we want (e.g., an id of "" should be treated as undefined, as in https://github.com/gpo/grassroots/issues/60).