### PR TITLE
fix: missing ValidateNested

### DIFF
--- a/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
+++ b/grassroots-backend/src/grassroots-shared/Contact.entity.dto.ts
@@ -22,6 +22,7 @@ export class CreateContactInDto {
 }
 
 export class CreateBulkContactRequestDto {
+  @ValidateNested()
   contacts!: CreateContactInDto[];
 }
 


### PR DESCRIPTION
Validation isn't recursive by default:
https://github.com/typestack/class-validator#validating-nested-objects

We are investigating if an eslint rule exists