### PR TITLE
dev: Allow passwordless sudo in devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN deluser node --remove-home \
     && groupadd -g ${GID} ${UNAME} \
     && useradd -g ${UNAME} -u ${UID} ${UNAME} -m \
     && echo "${UNAME} ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/${UNAME}-nopasswd \
-    && chmod 440 "/etc/sudoers.d/${UNAME}-nopasswd"
+    && chmod 440 /etc/sudoers.d/${UNAME}-nopasswd
 
 COPY --chmod=755 docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,14 @@ ARG GID=1000
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y sudo
+
 # First remove the node user to avoid uid/gid conflicts, then we create our user.
 RUN deluser node --remove-home \
     && groupadd -g ${GID} ${UNAME} \
-    && useradd -g ${UNAME} -u ${UID} ${UNAME} -m
+    && useradd -g ${UNAME} -u ${UID} ${UNAME} -m \
+    && echo "${UNAME} ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/${UNAME}-nopasswd \
+    && chmod 440 "/etc/sudoers.d/${UNAME}-nopasswd"
 
 COPY --chmod=755 docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/grassroots-backend/package-lock.json
+++ b/grassroots-backend/package-lock.json
@@ -1724,6 +1724,8 @@
     },
     "node_modules/@swc/cli": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
+      "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "globals": "^16.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.1",
-        "prettier": "^3.5.3",
+        "prettier": "^3.6.1",
         "react": "^19.0.0",
         "syncpack": "^13.0.4",
         "typescript-eslint": "^8.31.0"
@@ -4418,9 +4418,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
+      "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "globals": "^16.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.1",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.1",
     "react": "^19.0.0",
     "syncpack": "^13.0.4",
     "typescript-eslint": "^8.31.0"


### PR DESCRIPTION
enables managing individual dev containers from within the dev container
This was done to enable installing packages. See: https://github.com/gpo/grassroots/pull/109/files/6a25a1fee43b5ad9213478a5211127adcf52121f#r2164976548