### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,67 @@
 # grassroots
 
-Political Campaign Software focused on voter outreach and volunteer management.
+Political Campaign Software focused on voter outreach and volunteer
+management.
 
-# Setup
+# Recommended Development Setup
+
+We're running things in Docker. A simple, cross-platform development
+workflow might be:
 
 1. Run setup.sh.
-2. Add
 
+```sh
+./setup.sh
 ```
-$LOCAL_IP grassroots.org
+
+2. Update your hosts file
+
+Add the line
 ```
+127.0.0.1 grassroots.org
+```
+to your hosts file, `/etc/hosts`, assuming you're developing on the machine you're browsing from.
 
-to your /etc/hosts.
-
-That's:
+If you're one Windows, open Notepad as Administrator, then open
+`C:\Windows\System32\drivers\etc\hosts` and add:
 
 ```
 127.0.0.1 grassroots.org
 ```
 
-if you're developing on the machine you're browsing from.
+3. Install Docker
 
-3. start up docker dev environment (see [Running in Dev Mode](#devMode))
+4. Start up Docker in one terminal
 
-4. Run mikro-orm migration inside docker dev container
-
-```
-docker compose exec grassroots_dev bash -c "cd grassroots-backend && npx mikro-orm migration:up"
-```
-
-# Running in Dev Mode
-
-We're running things in Docker. A simple, cross-platform development workflow might be:
-
-1. Start up Docker in one terminal
 ```sh
 cd docker
 docker compose up
 ```
 
-2. In another terminal, set up and start the frontend in your now running `grassroots_dev` Docker container
+5. In another terminal, set up and run the frontend application in your now running `grassroots_dev` Docker container
 ```sh
+cd docker
 docker compose exec grassroots_dev /bin/bash
 cd grassroots-frontend
-npm install
 npm run start
 ```
 
-3. In another terminal, set up and start the backend in the same `grassroots_dev` Docker container
+6. In another terminal, set up and run the backend application in the same `grassroots_dev` Docker container
 ```sh
+cd docker
 docker compose exec grassroots_dev /bin/bash
-cd grassroots-frontend
-npm install
+cd grassroots-backend
+npx mikro-orm migration:up
 npm run start
 ```
 
-## Windows
-You might consider using [Git BASH](https://gitforwindows.org/) if you're developing on Windows.
+7. Access the running services
 
-## Environment Variables
+- Frontend: http://localhost:5173 or http://grassroots.org
+- Backend API: http://localhost:3000
+- Test API endpoint: http://localhost:3000/contacts
 
-Environment variables are read both within and outside the nestJS context (for mikro-orm.config.ts and GlobalSetup.ts). Due to this, we don't inject the ConfigModule for tests, instead, we define a different set of env files for development vs test.
-
-## Migrations
+# Migrations
 
 To migrate:
 
@@ -75,189 +74,3 @@ To create a migration to the current Entity schemas.
 ```sh
 npx mikro-orm migration:create
 ```
-
-## Frequently Seen Problems
-
-`duplicate key value violates unique constraint "pg_class_relname_nsp_index"`
-You're modifying tables from multiple threads at the same time. Serialize whatever you're doing!
-
-`Invalid hook call.`
-You might accidentally have installed a dependency in the root package, instead of the frontend package. I'm not sure why this causes this error. Remove the dependency from the root package, `npm prune`, install it in the frontend package, and restart vite.
-
-When migrating the database with `docker compose exec grassroots_dev bash -c "cd grassroots-backend && npx mikro-orm migration:up"` you get `MODULE_NOT_FOUND`
-
-```
-docker compose exec grassroots_dev bash -c "cd grassroots-backend && npm i"
-docker compose exec grassroots_dev bash -c "cd grassroots-backend && npm audit fix"
-docker compose exec grassroots_dev bash -c "cd grassroots-backend && npx mikro-orm migration:up"
-```
-
-# Grassroots Development Setup Windows
-
-## Prerequisites
-
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
-- Git (for cloning the repository)
-
-## Quick Start
-
-1. **Clone the repository**
-
-```bash
-git clone <repository-url>
-cd grassroots
-```
-
-2. **Set up local domain (Optional)**
-   **Windows:** Open Notepad as Administrator, then open `C:\Windows\System32\drivers\etc\hosts` and add:
-
-```
-127.0.0.1 grassroots.org
-```
-
-**macOS/Linux:** Edit `/etc/hosts` and add:
-
-```
-127.0.0.1 grassroots.org
-```
-
-3. **Start the application**
-
-```bash
-docker compose -f docker/compose.yaml up  --build
-```
-
-4. **Access the application**
-
-- Frontend: http://localhost:5173 or http://grassroots.local
-- Backend API: http://localhost:3000
-- Test API endpoint: http://localhost:3000/contacts
-
-## Development Workflow
-
-### Full Docker Setup (Recommended)
-
-Everything runs in containers, ensuring consistent environments across all platforms.
-
-```bash
-# Start all services
-docker compose -f docker/compose.yaml up --build
-
-# View logs
-docker compose -f docker/compose.yaml logs -f
-
-# Stop services
-docker compose -f docker/compose.yaml down
-```
-
-### Hybrid Setup (Alternative)
-
-If you prefer to run the applications locally while keeping the database in Docker:
-
-```bash
-# Start only the database
-docker compose -f docker/compose.yaml up db
-
-# Terminal 1 - Backend
-cd grassroots-backend
-npm install
-npm run start:dev
-
-# Terminal 2 - Frontend
-cd grassroots-frontend
-npm install
-npm run dev
-```
-
-## Troubleshooting
-
-### Container Issues
-
-**Check container status:**
-
-```bash
-docker compose -f docker/compose.yaml ps
-```
-
-**View container logs:**
-
-```bash
-docker compose -f docker/compose.yaml logs grassroots_dev
-docker compose -f docker/compose.yaml logs db
-```
-
-**Rebuild containers:**
-
-```bash
-docker compose -f docker/compose.yaml down
-docker compose -f docker/compose.yaml up --build
-```
-
-### Port Conflicts
-
-Ensure these ports are available:
-
-- **3000** - Backend API
-- **5173** - Frontend development server
-
-### Database Connection Issues
-
-1. Verify the database container is running:
-
-```bash
-docker compose -f docker/compose.yaml ps db
-```
-
-2. Check database logs:
-
-```bash
-docker compose -f docker/compose.yaml logs db
-```
-
-3. Test database connection:
-
-```bash
-docker exec -it db psql -U grassroots -d grassroots
-docker exec -it test_db psql -U grassroots -d grassroots
-```
-
-## Development Commands
-
-### Docker Commands
-
-```bash
-# Start development environment
-docker compose -f docker/compose.yaml up
-
-# Execute commands in containers
-docker exec -it grassroots_dev bash
-docker exec -it db psql -U grassroots grassroots
-docker exec -it test_db psql -U grassroots grassroots
-
-# Clean up everything
-docker compose -f docker/compose.yaml down -v
-docker system prune -f
-```
-
-### Application Commands (inside containers)
-
-```bash
-# Backend
-cd /app/grassroots-backend
-npm install
-npm run start:dev
-npm test
-
-# Frontend
-cd /app/grassroots-frontend
-npm install
-npm run dev
-npm run build
-```
-
-## Architecture
-
-- **Frontend**: React application served on port 5173
-- **Backend**: Node.js API server on port 3000
-- **Database**: PostgreSQL on port 5432
-- **Container Network**: All services communicate through Docker's internal network

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ management.
 We're running things in Docker. A simple, cross-platform development
 workflow might be:
 
-1. Run setup.sh.
+## 1. Run setup.sh.
 
 ```sh
 ./setup.sh
 ```
 
-2. Update your hosts file
+## 2. Update your hosts file
 
 Add the line
 ```
@@ -29,16 +29,16 @@ If you're one Windows, open Notepad as Administrator, then open
 127.0.0.1 grassroots.org
 ```
 
-3. Install Docker
+## 3. Install Docker
 
-4. Start up Docker in one terminal
+## 4. Start up Docker in one terminal
 
 ```sh
 cd docker
 docker compose up
 ```
 
-5. In another terminal, set up and run the frontend application in your now running `grassroots_dev` Docker container
+## 5. In another terminal, set up and run the frontend application in your now running `grassroots_dev` Docker container
 ```sh
 cd docker
 docker compose exec grassroots_dev /bin/bash
@@ -46,7 +46,7 @@ cd grassroots-frontend
 npm run start
 ```
 
-6. In another terminal, set up and run the backend application in the same `grassroots_dev` Docker container
+## 6. In another terminal, set up and run the backend application in the same `grassroots_dev` Docker container
 ```sh
 cd docker
 docker compose exec grassroots_dev /bin/bash
@@ -55,7 +55,7 @@ npx mikro-orm migration:up
 npm run start
 ```
 
-7. Access the running services
+## 7. Access the running services
 
 - Frontend: http://localhost:5173 or http://grassroots.org
 - Backend API: http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ management.
 
 # Recommended Development Setup
 
-We're running things in Docker. A simple, cross-platform development
-workflow might be:
+First, make sure you've installed
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+- Git (for cloning the repository)
+- Node.JS
+
+We're running things in Docker. We can develop our code in a running
+Docker container to keep the development environment consistent
+regardless of your OS. A simple, cross-platform development workflow
+might be:
 
 ## 1. Run setup.sh.
 
@@ -22,41 +29,38 @@ Add the line
 ```
 to your hosts file, `/etc/hosts`, assuming you're developing on the machine you're browsing from.
 
-If you're one Windows, open Notepad as Administrator, then open
+If you're on Windows, open Notepad as Administrator, then open
 `C:\Windows\System32\drivers\etc\hosts` and add:
 
 ```
 127.0.0.1 grassroots.org
 ```
 
-## 3. Install Docker
-
-## 4. Start up Docker in one terminal
+## 3. Start up Docker in one terminal
 
 ```sh
 cd docker
 docker compose up
 ```
 
-## 5. In another terminal, set up and run the frontend application in your now running `grassroots_dev` Docker container
+## 4. In another terminal, set up and run the frontend application in your now running `grassroots_dev` Docker container
 ```sh
 cd docker
-docker compose exec grassroots_dev /bin/bash
+docker compose exec grassroots_dev bash
 cd grassroots-frontend
 npm run start
 ```
 
-## 6. In another terminal, set up and run the backend application in the same `grassroots_dev` Docker container
+## 5. In another terminal, set up and run the backend application in the same `grassroots_dev` Docker container
 ```sh
 cd docker
-docker compose exec grassroots_dev /bin/bash
+docker compose exec grassroots_dev bash
 cd grassroots-backend
 npx mikro-orm migration:up
 npm run start
 ```
 
-## 7. Access the running services
-
+## 6. Access the running services
 - Frontend: http://localhost:5173 or http://grassroots.org
 - Backend API: http://localhost:3000
 - Test API endpoint: http://localhost:3000/contacts

--- a/README.md
+++ b/README.md
@@ -31,35 +31,32 @@ docker compose exec grassroots_dev bash -c "cd grassroots-backend && npx mikro-o
 
 # Running in Dev Mode
 
-We're running things in docker.
+We're running things in Docker. A simple, cross-platform development workflow might be:
 
-### On Mac or Linux:
-
+1. Start up Docker in one terminal
 ```sh
 cd docker
 docker compose up
-docker compose exec grassroots_dev /bin/bash -c "cd grassroots-frontend && npm run dev" # Frontend
-docker compose exec grassroots_dev /bin/bash -c "cd grassroots-backend && npm run start:dev" # Backend
 ```
 
-### On Windows:
-
-1. Start up Docker
-
-2. Terminal 1: (git bash)
-
-```
-cd docker
-docker compose build grassroots_dev
-docker compose up
+2. In another terminal, set up and start the frontend in your now running `grassroots_dev` Docker container
+```sh
+docker compose exec grassroots_dev /bin/bash
+cd grassroots-frontend
+npm install
+npm run start
 ```
 
-3. Terminals 2 & 3: (git bash)
+3. In another terminal, set up and start the backend in the same `grassroots_dev` Docker container
+```sh
+docker compose exec grassroots_dev /bin/bash
+cd grassroots-frontend
+npm install
+npm run start
+```
 
-```
-cd docker && docker compose exec grassroots_dev bash -c "cd grassroots-frontend && npm run dev"
-cd docker && docker compose exec grassroots_dev bash -c "cd grassroots-backend && npm run start:dev"
-```
+## Windows
+You might consider using [Git BASH](https://gitforwindows.org/) if you're developing on Windows.
 
 ## Environment Variables
 

--- a/README_ARCHITECTURE.md
+++ b/README_ARCHITECTURE.md
@@ -1,0 +1,7 @@
+# Architecture
+
+- **Frontend**: React application served on port 5173
+- **Backend**: Node.js API server on port 3000
+- **Database**: PostgreSQL on port 5432
+- **Container Network**: All services communicate through Docker's
+  internal network

--- a/README_TROUBLESHOOTING.md
+++ b/README_TROUBLESHOOTING.md
@@ -1,0 +1,95 @@
+
+# Frequently Seen Problems
+
+`duplicate key value violates unique constraint
+"pg_class_relname_nsp_index"` You're modifying tables from multiple
+threads at the same time. Serialize whatever you're doing!
+
+`Invalid hook call.`  You might accidentally have installed a
+dependency in the root package, instead of the frontend package. I'm
+not sure why this causes this error. Remove the dependency from the
+root package, `npm prune`, install it in the frontend package, and
+restart vite.
+
+When migrating the database with `docker compose exec grassroots_dev
+bash -c "cd grassroots-backend && npx mikro-orm migration:up"` you get
+`MODULE_NOT_FOUND`
+
+```
+docker compose exec grassroots_dev bash -c "cd grassroots-backend && npm i"
+docker compose exec grassroots_dev bash -c "cd grassroots-backend && npm audit fix"
+docker compose exec grassroots_dev bash -c "cd grassroots-backend && npx mikro-orm migration:up"
+```
+
+# Environment Variables
+
+Environment variables are read both within and outside the nestJS
+context (for mikro-orm.config.ts and GlobalSetup.ts). Due to this, we
+don't inject the ConfigModule for tests, instead, we define a
+different set of env files for development vs test.
+
+# Container Issues
+
+**Check container status:**
+
+```bash
+docker compose -f docker/compose.yaml ps
+```
+
+**View container logs:**
+
+```bash
+docker compose -f docker/compose.yaml logs grassroots_dev
+docker compose -f docker/compose.yaml logs db
+```
+
+**Rebuild containers:**
+
+```bash
+docker compose -f docker/compose.yaml down
+docker compose -f docker/compose.yaml up --build
+```
+
+# Port Conflicts
+
+Ensure these ports are available:
+
+- **3000** - Backend API
+- **5173** - Frontend development server
+
+# Database Connection Issues
+
+1. Verify the database container is running:
+
+```bash
+docker compose -f docker/compose.yaml ps db
+```
+
+2. Check database logs:
+
+```bash
+docker compose -f docker/compose.yaml logs db
+```
+
+3. Test database connection:
+
+```bash
+docker exec -it db psql -U grassroots -d grassroots
+docker exec -it test_db psql -U grassroots -d grassroots
+```
+
+# Miscellaneous Docker Commands
+
+```bash
+# Start development environment
+docker compose -f docker/compose.yaml up
+
+# Execute commands in containers
+docker exec -it grassroots_dev bash
+docker exec -it db psql -U grassroots grassroots
+docker exec -it test_db psql -U grassroots grassroots
+
+# Clean up everything
+docker compose -f docker/compose.yaml down -v
+docker system prune -f
+```


### PR DESCRIPTION
Maybe I went overboard :sweat_smile: 

- `npm run start:dev` doesn't exist, use `npm run start`
- Move troubleshooting stuff to README_TROUBLESHOOTING.md
- Move architecture stuff to README_ARCHITECTURE.md
- Remove some redundant information
- Make notes about developing on Windows, but I think the same commands should work for everyone?