### PR TITLE
Add button for adding random data

### DIFF
--- a/grassroots-frontend/package-lock.json
+++ b/grassroots-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "grassroots-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@faker-js/faker": "^9.9.0",
         "@mantine/core": "^7.17.4",
         "@mantine/hooks": "^7.17.4",
         "@tanstack/react-query": "^5.74.11",
@@ -739,6 +740,22 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/grassroots-frontend/package.json
+++ b/grassroots-frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.9.0",
     "@mantine/core": "^7.17.4",
     "@mantine/hooks": "^7.17.4",
     "@tanstack/react-query": "^5.74.11",

--- a/grassroots-frontend/src/components/devtools/AddFakeDataButton.tsx
+++ b/grassroots-frontend/src/components/devtools/AddFakeDataButton.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@mantine/core";
+import { JSX } from "react";
+import { grassrootsAPI } from "../../GrassRootsAPI";
+import { CreateContactRequestDto } from "../../grassroots-shared/Contact.dto";
+import { faker } from "@faker-js/faker";
+
+function getRandomContact(): CreateContactRequestDto {
+  return {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email(),
+    phoneNumber: faker.phone.number(),
+  };
+}
+
+async function populateFakeData(): Promise<void> {
+  const contacts = [];
+
+  for (let i = 0; i < 100; ++i) {
+    contacts.push(getRandomContact());
+  }
+  await grassrootsAPI.POST("/contacts/bulk-create", {
+    body: {
+      contacts,
+    },
+  });
+}
+
+export function AddFakeDataButton(): JSX.Element {
+  return (
+    <Button
+      onClick={
+        void (async (): Promise<void> => {
+          await populateFakeData();
+        })
+      }
+    >
+      Add 100 Random Contacts
+    </Button>
+  );
+}

--- a/grassroots-frontend/src/components/devtools/AddFakeDataButton.tsx
+++ b/grassroots-frontend/src/components/devtools/AddFakeDataButton.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@mantine/core";
 import { JSX } from "react";
 import { grassrootsAPI } from "../../GrassRootsAPI";
-import { CreateContactRequestDto } from "../../grassroots-shared/Contact.dto";
+import { CreateContactRequestDTO } from "../../grassroots-shared/Contact.dto";
 import { faker } from "@faker-js/faker";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-function getRandomContact(): CreateContactRequestDto {
+function getRandomContact(): CreateContactRequestDTO {
   // Generating valid phone numbers is tough, so we restrict the possible values.
   const phoneNumber =
     "226-" +

--- a/grassroots-frontend/src/components/devtools/DevTools.tsx
+++ b/grassroots-frontend/src/components/devtools/DevTools.tsx
@@ -1,0 +1,38 @@
+import { Affix, AppShell, Button, Drawer } from "@mantine/core";
+import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { JSX, useState } from "react";
+import { AddFakeDataButton } from "./AddFakeDataButton";
+
+export function DevTools(): JSX.Element {
+  const [devtoolsOpen, setDevtoolsShown] = useState(false);
+  return (
+    <>
+      <Affix position={{ bottom: 20, right: 20 }}>
+        <Button
+          onClick={() => {
+            setDevtoolsShown(true);
+          }}
+        >
+          Devtools
+        </Button>
+      </Affix>
+      <Drawer
+        position="right"
+        opened={devtoolsOpen}
+        onClose={() => {
+          setDevtoolsShown(false);
+        }}
+        title="Devtools"
+      >
+        <AppShell.Navbar>
+          <AppShell.Section>
+            <AddFakeDataButton></AddFakeDataButton>
+          </AppShell.Section>
+          <AppShell.Section>
+            <TanStackRouterDevtools />
+          </AppShell.Section>
+        </AppShell.Navbar>
+      </Drawer>
+    </>
+  );
+}

--- a/grassroots-frontend/src/grassroots-shared
+++ b/grassroots-frontend/src/grassroots-shared
@@ -1,1 +1,1 @@
-../../grassroots-backend/src/grassroots-shared/
+/app/grassroots-backend/src/grassroots-shared

--- a/grassroots-frontend/src/grassroots-shared
+++ b/grassroots-frontend/src/grassroots-shared
@@ -1,1 +1,1 @@
-/app/grassroots-backend/src/grassroots-shared
+../../grassroots-backend/src/grassroots-shared/

--- a/grassroots-frontend/src/routes/__root.tsx
+++ b/grassroots-frontend/src/routes/__root.tsx
@@ -7,6 +7,8 @@ import { AppShell, Button, MantineProvider, ScrollArea } from "@mantine/core";
 import { RoutedLink } from "../components/RoutedLink";
 import { navigateToBackendRoute } from "../GrassRootsAPI";
 import { LoginState } from "../context/LoginStateContext";
+import { populateFakeData } from "../devtools/populateFakeData";
+import { AddFakeDataButton } from "../components/devtools/AddFakeDataButton";
 
 interface RouterContext {
   loginState: Promise<LoginState | undefined>;
@@ -39,9 +41,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
           <AppShell.Section>
             <RoutedLink to="/Users">Users</RoutedLink>
           </AppShell.Section>
-          <AppShell.Section>
-            <Button>Add 100 Random Contacts</Button>
-          </AppShell.Section>
+          {import.meta.env.MODE === "development" ? (
+            <AppShell.Section>
+              <AddFakeDataButton></AddFakeDataButton>
+            </AppShell.Section>
+          ) : null}
           <AppShell.Section grow component={ScrollArea}></AppShell.Section>
           <AppShell.Section>
             <TanStackRouterDevtools />

--- a/grassroots-frontend/src/routes/__root.tsx
+++ b/grassroots-frontend/src/routes/__root.tsx
@@ -1,13 +1,12 @@
 import "@mantine/core/styles.css";
 
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
 import { AppShell, MantineProvider, ScrollArea } from "@mantine/core";
 import { RoutedLink } from "../components/RoutedLink";
 import { navigateToBackendRoute } from "../GrassRootsAPI";
 import { LoginState } from "../context/LoginStateContext";
-import { AddFakeDataButton } from "../components/devtools/AddFakeDataButton";
+import { DevTools } from "../components/devtools/DevTools";
 
 interface RouterContext {
   loginState: Promise<LoginState | undefined>;
@@ -40,20 +39,13 @@ export const Route = createRootRouteWithContext<RouterContext>()({
           <AppShell.Section>
             <RoutedLink to="/Users">Users</RoutedLink>
           </AppShell.Section>
-          {import.meta.env.MODE === "development" ? (
-            <AppShell.Section>
-              <AddFakeDataButton></AddFakeDataButton>
-            </AppShell.Section>
-          ) : null}
           <AppShell.Section grow component={ScrollArea}></AppShell.Section>
-          <AppShell.Section>
-            <TanStackRouterDevtools />
-          </AppShell.Section>
         </AppShell.Navbar>
 
         <AppShell.Main>
           <Outlet />
         </AppShell.Main>
+        <DevTools></DevTools>
       </AppShell>
     </MantineProvider>
   ),

--- a/grassroots-frontend/src/routes/__root.tsx
+++ b/grassroots-frontend/src/routes/__root.tsx
@@ -3,11 +3,10 @@ import "@mantine/core/styles.css";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
-import { AppShell, Button, MantineProvider, ScrollArea } from "@mantine/core";
+import { AppShell, MantineProvider, ScrollArea } from "@mantine/core";
 import { RoutedLink } from "../components/RoutedLink";
 import { navigateToBackendRoute } from "../GrassRootsAPI";
 import { LoginState } from "../context/LoginStateContext";
-import { populateFakeData } from "../devtools/populateFakeData";
 import { AddFakeDataButton } from "../components/devtools/AddFakeDataButton";
 
 interface RouterContext {


### PR DESCRIPTION
This is a replacement for https://github.com/gpo/grassroots/pull/19 .

As we chatted about a while back, I like having this kind of development tool in the frontend, as it lets us test some of the caching / cache busting behavior built into tanstack query, which we're likely to rely on for offline support. This is nicer if the button is in the sidebar, not on a separate route.

I'm planning to include "Add a tree of organizations" to the functionality of this button at some point (and change it's title).