### PR TITLE
Add eslint rules for dto and entity definition and usage

### DIFF
--- a/eslint_rules/README.md
+++ b/eslint_rules/README.md
@@ -1,6 +1,7 @@
 # Grassroots eslint rules.
 
 Currently built manually via `npm run tsc`.
+e.g., from the root, run `npm run tsc --prefix eslint_rules && npx eslint .`.
 
 ## Rules
 

--- a/eslint_rules/src/index.ts
+++ b/eslint_rules/src/index.ts
@@ -33,6 +33,7 @@ export const parser: TSESLint.FlatConfig.Parser = {
 
 const recommended: Partial<Linter.RulesRecord> = {
   "grassroots/dto-and-entity-style": "error",
+  "grassroots/entity-use": "error",
 };
 
 const flatBaseConfig = (

--- a/eslint_rules/src/rules/dto-and-entity-style.test.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.test.ts
@@ -1,27 +1,7 @@
-import path from "node:path";
-import tseslint from "typescript-eslint";
-import { RuleTester } from "@typescript-eslint/rule-tester";
-import * as vitest from "vitest";
-
 import { rule } from "./dto-and-entity-style.js";
+import { createRuleTester } from "../utils.js";
 
-RuleTester.afterAll = vitest.afterAll;
-RuleTester.it = vitest.it;
-RuleTester.itOnly = vitest.it.only;
-RuleTester.describe = vitest.describe;
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: tseslint.parser,
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-        defaultProject: "tsconfig.json",
-      },
-      tsconfigRootDir: path.join(__dirname, "../.."),
-    },
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run("definite-or-optional", rule, {
   valid: [

--- a/eslint_rules/src/rules/dto-and-entity-style.test.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.test.ts
@@ -68,5 +68,23 @@ ruleTester.run("definite-or-optional", rule, {
         },
       ],
     },
+
+    {
+      code: `class FooDTO {
+        a!: number;
+        constructor(a: number) {
+          this.a = a;
+        }
+      }`,
+      errors: [
+        {
+          column: 9,
+          endColumn: 10,
+          line: 3,
+          endLine: 5,
+          messageId: "noConstructors",
+        },
+      ],
+    },
   ],
 });

--- a/eslint_rules/src/rules/dto-and-entity-style.test.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.test.ts
@@ -1,5 +1,5 @@
 import { rule } from "./dto-and-entity-style.js";
-import { createRuleTester } from "../utils.js";
+import { createRuleTester } from "../test-utils.js";
 
 const ruleTester = createRuleTester();
 

--- a/eslint_rules/src/rules/dto-and-entity-style.test.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.test.ts
@@ -44,5 +44,29 @@ ruleTester.run("definite-or-optional", rule, {
         },
       ],
     },
+    {
+      code: `class FooDto { a!: number}`,
+      errors: [
+        {
+          column: 1,
+          endColumn: 27,
+          line: 1,
+          endLine: 1,
+          messageId: "classNameRules",
+        },
+      ],
+    },
+    {
+      code: `class FooDTOMagic { a!: number}`,
+      errors: [
+        {
+          column: 1,
+          endColumn: 32,
+          line: 1,
+          endLine: 1,
+          messageId: "classNameRules",
+        },
+      ],
+    },
   ],
 });

--- a/eslint_rules/src/rules/dto-and-entity-style.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.ts
@@ -30,7 +30,6 @@ function handleMethodDefinition(
     return;
   }
   if (element.key.name === "constructor") {
-    console.log("have constructor");
     context.report({
       messageId: "noConstructors",
       node: element,
@@ -46,7 +45,9 @@ export const rule = createRule({
         if (name === undefined) {
           return;
         }
-        if (!/(DTO|Entity)/i.exec(name)) {
+        const isDTO = /dto/i.exec(name);
+        const isEntity = /entity/i.exec(name);
+        if (!isDTO && !isEntity) {
           return;
         }
         // We need to match case sensitively, and DTO / Entity should be at the end of the class name.
@@ -65,7 +66,6 @@ export const rule = createRule({
               handleMethodDefinition(element, context);
               break;
             default:
-              console.log(element);
               break;
           }
         }

--- a/eslint_rules/src/rules/dto-and-entity-style.ts
+++ b/eslint_rules/src/rules/dto-and-entity-style.ts
@@ -3,7 +3,7 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 import { createRule } from "../utils.js";
 import { RuleContext, RuleListener } from "@typescript-eslint/utils/ts-eslint";
 
-type MessageIds = "definiteOrOptional";
+type MessageIds = "definiteOrOptional" | "classNameRules";
 
 export const rule = createRule({
   create(context: Readonly<RuleContext<MessageIds, []>>): RuleListener {
@@ -13,8 +13,15 @@ export const rule = createRule({
         if (name === undefined) {
           return;
         }
-        if (!/(DTO|Entity)/.exec(name)) {
+        if (!/(DTO|Entity)/i.exec(name)) {
           return;
+        }
+        // We need to match case sensitively, and DTO / Entity should be at the end of the class name.
+        if (!/(DTO|Entity)$/.exec(name)) {
+          context.report({
+            messageId: "classNameRules",
+            node,
+          });
         }
         for (const element of node.body.body) {
           if (element.type !== AST_NODE_TYPES.PropertyDefinition) {
@@ -40,6 +47,7 @@ export const rule = createRule({
       definiteOrOptional: `Properties must be definite (with a ! suffix) or optional (with a ? suffix).
         Since these objects are constructed via class-transformer, they won't be initialized in the constructor.
         This lets typescript know that it can assume they're present despite this.`,
+      classNameRules: `DTOs and Entity class names must end in DTO or Entity, case sensitive`,
     },
     type: "suggestion",
     schema: [],

--- a/eslint_rules/src/rules/entity-use.test.ts
+++ b/eslint_rules/src/rules/entity-use.test.ts
@@ -20,8 +20,21 @@ ruleTester.run("entity-use", rule, {
       code: `let x: FooEntity = y;`,
       errors: [
         {
-          column: 1,
-          endColumn: 22,
+          column: 8,
+          endColumn: 17,
+          line: 1,
+          endLine: 1,
+          messageId: "noEntityAccessOutsideServices",
+        },
+      ],
+    },
+    {
+      filename: "foo.controller.ts",
+      code: `console.log(x as FooEntity);`,
+      errors: [
+        {
+          column: 18,
+          endColumn: 27,
           line: 1,
           endLine: 1,
           messageId: "noEntityAccessOutsideServices",

--- a/eslint_rules/src/rules/entity-use.test.ts
+++ b/eslint_rules/src/rules/entity-use.test.ts
@@ -1,0 +1,28 @@
+import { rule } from "./entity-use.js";
+import { createRuleTester } from "../utils.js";
+
+const ruleTester = createRuleTester();
+
+ruleTester.run("entity-use", rule, {
+  valid: [
+    {
+      filename: "foo.entity.ts",
+      code: `let x: FooEntity = y;`,
+    },
+  ],
+  invalid: [
+    {
+      filename: "foo.controller.ts",
+      code: `let x: FooEntity = y;`,
+      errors: [
+        {
+          column: 1,
+          endColumn: 22,
+          line: 1,
+          endLine: 1,
+          messageId: "noEntityAccessOutsideServices",
+        },
+      ],
+    },
+  ],
+});

--- a/eslint_rules/src/rules/entity-use.test.ts
+++ b/eslint_rules/src/rules/entity-use.test.ts
@@ -1,5 +1,5 @@
 import { rule } from "./entity-use.js";
-import { createRuleTester } from "../utils.js";
+import { createRuleTester } from "../test-utils.js";
 
 const ruleTester = createRuleTester();
 
@@ -8,6 +8,10 @@ ruleTester.run("entity-use", rule, {
     {
       filename: "foo.entity.ts",
       code: `let x: FooEntity = y;`,
+    },
+    {
+      filename: "foo.controller.ts",
+      code: `let em:EntityManager;`,
     },
   ],
   invalid: [

--- a/eslint_rules/src/rules/entity-use.ts
+++ b/eslint_rules/src/rules/entity-use.ts
@@ -10,7 +10,6 @@ function checkEntityFilename(
   node: TSESTree.VariableDeclaration,
   context: Context,
 ): void {
-  console.log(context.filename);
   if (
     !context.filename.includes("service") &&
     !context.filename.includes("entity")
@@ -37,7 +36,7 @@ export const rule = createRule({
           if (typeName.type !== TSESTree.AST_NODE_TYPES.Identifier) {
             continue;
           }
-          if (!typeName.name.includes("Entity")) {
+          if (!/.*Entity$/.exec(typeName.name)) {
             continue;
           }
           checkEntityFilename(node, context);

--- a/eslint_rules/src/rules/entity-use.ts
+++ b/eslint_rules/src/rules/entity-use.ts
@@ -1,0 +1,62 @@
+import { TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.js";
+import { RuleContext, RuleListener } from "@typescript-eslint/utils/ts-eslint";
+
+type MessageIds = "noEntityAccessOutsideServices";
+type Context = Readonly<RuleContext<MessageIds, []>>;
+
+function checkEntityFilename(
+  node: TSESTree.VariableDeclaration,
+  context: Context,
+): void {
+  console.log(context.filename);
+  if (
+    !context.filename.includes("service") &&
+    !context.filename.includes("entity")
+  ) {
+    context.report({
+      messageId: "noEntityAccessOutsideServices",
+      node: node,
+    });
+  }
+}
+
+export const rule = createRule({
+  create(context: Context): RuleListener {
+    return {
+      VariableDeclaration(node: TSESTree.VariableDeclaration): undefined {
+        for (const declaration of node.declarations) {
+          const typeAnnotation = declaration.id.typeAnnotation?.typeAnnotation;
+          if (
+            typeAnnotation?.type !== TSESTree.AST_NODE_TYPES.TSTypeReference
+          ) {
+            continue;
+          }
+          const typeName = typeAnnotation.typeName;
+          if (typeName.type !== TSESTree.AST_NODE_TYPES.Identifier) {
+            continue;
+          }
+          if (!typeName.name.includes("Entity")) {
+            continue;
+          }
+          checkEntityFilename(node, context);
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: "Ensure Entities are only used where appropriate.",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    messages: {
+      noEntityAccessOutsideServices: `Entity usage should only occur within services. Outside services, we should use the DTOs.`,
+    },
+    type: "suggestion",
+    schema: [],
+  },
+  name: "entity-use",
+  defaultOptions: [],
+});

--- a/eslint_rules/src/rules/index.ts
+++ b/eslint_rules/src/rules/index.ts
@@ -1,8 +1,10 @@
 /* eslint-disable check-file/no-index */
 import { rule as dtoAndEntityStyle } from "./dto-and-entity-style.js";
+import { rule as entityUse } from "./entity-use.js";
 
 const rules = {
   "dto-and-entity-style": dtoAndEntityStyle,
+  "entity-use": entityUse,
 };
 
 export default rules;

--- a/eslint_rules/src/test-utils.ts
+++ b/eslint_rules/src/test-utils.ts
@@ -1,0 +1,26 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import path from "path";
+import tseslint from "typescript-eslint";
+import * as vitest from "vitest";
+
+export function createRuleTester(): RuleTester {
+  RuleTester.afterAll = vitest.afterAll;
+  RuleTester.it = vitest.it;
+  RuleTester.itOnly = vitest.it.only;
+  RuleTester.describe = vitest.describe;
+
+  const ruleTester = new RuleTester({
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["*.ts*"],
+          defaultProject: "tsconfig.json",
+        },
+        tsconfigRootDir: path.join(__dirname, ".."),
+      },
+    },
+  });
+
+  return ruleTester;
+}

--- a/eslint_rules/src/utils.ts
+++ b/eslint_rules/src/utils.ts
@@ -1,4 +1,9 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
 import { ESLintUtils } from "@typescript-eslint/utils";
+import path from "path";
+import tseslint from "typescript-eslint";
+import * as vitest from "vitest";
 
 export interface ExampleTypedLintingRuleDocs {
   description: string;
@@ -10,3 +15,25 @@ export const createRule = ESLintUtils.RuleCreator<ExampleTypedLintingRuleDocs>(
   (name) =>
     `https://github.com/typescript-eslint/examples/tree/main/eslint-plugin-example-typed-linting/docs/${name}.md`,
 );
+
+export function createRuleTester(): RuleTester {
+  RuleTester.afterAll = vitest.afterAll;
+  RuleTester.it = vitest.it;
+  RuleTester.itOnly = vitest.it.only;
+  RuleTester.describe = vitest.describe;
+
+  const ruleTester = new RuleTester({
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["*.ts*"],
+          defaultProject: "tsconfig.json",
+        },
+        tsconfigRootDir: path.join(__dirname, ".."),
+      },
+    },
+  });
+
+  return ruleTester;
+}

--- a/eslint_rules/src/utils.ts
+++ b/eslint_rules/src/utils.ts
@@ -1,9 +1,4 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
-
 import { ESLintUtils } from "@typescript-eslint/utils";
-import path from "path";
-import tseslint from "typescript-eslint";
-import * as vitest from "vitest";
 
 export interface ExampleTypedLintingRuleDocs {
   description: string;
@@ -15,25 +10,3 @@ export const createRule = ESLintUtils.RuleCreator<ExampleTypedLintingRuleDocs>(
   (name) =>
     `https://github.com/typescript-eslint/examples/tree/main/eslint-plugin-example-typed-linting/docs/${name}.md`,
 );
-
-export function createRuleTester(): RuleTester {
-  RuleTester.afterAll = vitest.afterAll;
-  RuleTester.it = vitest.it;
-  RuleTester.itOnly = vitest.it.only;
-  RuleTester.describe = vitest.describe;
-
-  const ruleTester = new RuleTester({
-    languageOptions: {
-      parser: tseslint.parser,
-      parserOptions: {
-        projectService: {
-          allowDefaultProject: ["*.ts*"],
-          defaultProject: "tsconfig.json",
-        },
-        tsconfigRootDir: path.join(__dirname, ".."),
-      },
-    },
-  });
-
-  return ruleTester;
-}

--- a/grassroots-backend/src/auth/GoogleOAuth.strategy.ts
+++ b/grassroots-backend/src/auth/GoogleOAuth.strategy.ts
@@ -9,7 +9,7 @@ import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { UsersService } from "../users/Users.service";
 import OpenIDConnectStrategy from "passport-openidconnect";
-import { UserEntity } from "../users/User.entity";
+import { UserDTO } from "../grassroots-shared/User.dto";
 
 export const DEFAULT_PASSPORT_STRATEGY_NAME = "google";
 
@@ -49,7 +49,7 @@ export class GoogleOAuthStrategy extends PassportStrategy(
     done: VerifyCallback,
   ): Promise<void> => {
     const id = profile.id;
-    let user: UserEntity | undefined = undefined;
+    let user: UserDTO | undefined = undefined;
     try {
       user = await this.userService.findOrCreate({
         id,

--- a/grassroots-backend/src/testing/MockAuthGuard.ts
+++ b/grassroots-backend/src/testing/MockAuthGuard.ts
@@ -1,8 +1,8 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { GrassrootsRequest } from "../types/GrassrootsRequest";
-import { UserEntity } from "../users/User.entity";
+import { UserDTO } from "../grassroots-shared/User.dto";
 
-export const MOCK_AUTH_GUARD_USER: UserEntity = {
+export const MOCK_AUTH_GUARD_USER: UserDTO = {
   id: "testid",
   emails: ["test@example.com"],
   displayName: "Test Example",

--- a/grassroots-backend/src/types/GrassrootsRequest.d.ts
+++ b/grassroots-backend/src/types/GrassrootsRequest.d.ts
@@ -1,4 +1,4 @@
 import { Request } from "express";
-import { UserEntity } from "../users/User.entity";
+import { UserDTO } from "../grassroots-shared/User.dto";
 
-export type GrassrootsRequest = Request & UserEntity;
+export type GrassrootsRequest = Request & UserDTO;


### PR DESCRIPTION
Enforces class name case, and that DTO / Entity must be at the end of the class name.
No constructors allowed in DTOs or entities.
No variables declared with entity types outside of services.