### PR TITLE
pre-commit hook sometimes doesn't run reliably

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./run npx lint-staged
+npx lint-staged


### PR DESCRIPTION
the ./run makes it slower and causes issues