### PR TITLE
Adding pnpm store to gitignore to prevent craziness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ grassroots-frontend/vite.config.js
 .env.test.local
 .env.local
 
+#Package pointer store
+.pnpm-store
 
 # CI
 eslint_report.json


### PR DESCRIPTION
There will be a .pnpm-store that will store thousands of json pointer files to speed things up.
having a gitignore line seems to be good and standard practice