### PR TITLE
CASL part 1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@
 **/openAPI.json
 grassroots-backend/src/migrations/
 grassroots-backend/src/metadata.ts
-doc/schema/schema.json

--- a/doc/schema/schema.json
+++ b/doc/schema/schema.json
@@ -28,9 +28,7 @@
           "name": "mikro_orm_migrations_pkey",
           "def": "CREATE UNIQUE INDEX mikro_orm_migrations_pkey ON public.mikro_orm_migrations USING btree (id)",
           "table": "public.mikro_orm_migrations",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ],
       "constraints": [
@@ -40,9 +38,7 @@
           "def": "PRIMARY KEY (id)",
           "table": "public.mikro_orm_migrations",
           "referenced_table": "",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ]
     },
@@ -81,9 +77,7 @@
           "name": "user_entity_pkey",
           "def": "CREATE UNIQUE INDEX user_entity_pkey ON public.user_entity USING btree (id)",
           "table": "public.user_entity",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ],
       "constraints": [
@@ -93,9 +87,7 @@
           "def": "PRIMARY KEY (id)",
           "table": "public.user_entity",
           "referenced_table": "",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ]
     },
@@ -125,9 +117,7 @@
           "name": "organization_entity_pkey",
           "def": "CREATE UNIQUE INDEX organization_entity_pkey ON public.organization_entity USING btree (id)",
           "table": "public.organization_entity",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ],
       "constraints": [
@@ -137,12 +127,8 @@
           "def": "FOREIGN KEY (parent_id) REFERENCES organization_entity(id) ON UPDATE CASCADE ON DELETE SET NULL",
           "table": "public.organization_entity",
           "referenced_table": "organization_entity",
-          "columns": [
-            "parent_id"
-          ],
-          "referenced_columns": [
-            "id"
-          ]
+          "columns": ["parent_id"],
+          "referenced_columns": ["id"]
         },
         {
           "name": "organization_entity_pkey",
@@ -150,9 +136,7 @@
           "def": "PRIMARY KEY (id)",
           "table": "public.organization_entity",
           "referenced_table": "",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ]
     },
@@ -197,17 +181,13 @@
           "name": "contact_entity_pkey",
           "def": "CREATE UNIQUE INDEX contact_entity_pkey ON public.contact_entity USING btree (id)",
           "table": "public.contact_entity",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         },
         {
           "name": "contact_entity_email_unique",
           "def": "CREATE UNIQUE INDEX contact_entity_email_unique ON public.contact_entity USING btree (email)",
           "table": "public.contact_entity",
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       ],
       "constraints": [
@@ -217,12 +197,8 @@
           "def": "FOREIGN KEY (organization_id) REFERENCES organization_entity(id) ON UPDATE CASCADE",
           "table": "public.contact_entity",
           "referenced_table": "organization_entity",
-          "columns": [
-            "organization_id"
-          ],
-          "referenced_columns": [
-            "id"
-          ]
+          "columns": ["organization_id"],
+          "referenced_columns": ["id"]
         },
         {
           "name": "contact_entity_pkey",
@@ -230,9 +206,7 @@
           "def": "PRIMARY KEY (id)",
           "table": "public.contact_entity",
           "referenced_table": "",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         },
         {
           "name": "contact_entity_email_unique",
@@ -240,9 +214,7 @@
           "def": "UNIQUE (email)",
           "table": "public.contact_entity",
           "referenced_table": "",
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       ]
     },
@@ -282,9 +254,7 @@
           "name": "user_role_entity_pkey",
           "def": "CREATE UNIQUE INDEX user_role_entity_pkey ON public.user_role_entity USING btree (id)",
           "table": "public.user_role_entity",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ],
       "constraints": [
@@ -294,12 +264,8 @@
           "def": "FOREIGN KEY (user_id) REFERENCES user_entity(id) ON UPDATE CASCADE",
           "table": "public.user_role_entity",
           "referenced_table": "user_entity",
-          "columns": [
-            "user_id"
-          ],
-          "referenced_columns": [
-            "id"
-          ]
+          "columns": ["user_id"],
+          "referenced_columns": ["id"]
         },
         {
           "name": "user_role_entity_organization_id_foreign",
@@ -307,12 +273,8 @@
           "def": "FOREIGN KEY (organization_id) REFERENCES organization_entity(id) ON UPDATE CASCADE",
           "table": "public.user_role_entity",
           "referenced_table": "organization_entity",
-          "columns": [
-            "organization_id"
-          ],
-          "referenced_columns": [
-            "id"
-          ]
+          "columns": ["organization_id"],
+          "referenced_columns": ["id"]
         },
         {
           "name": "user_role_entity_pkey",
@@ -320,9 +282,7 @@
           "def": "PRIMARY KEY (id)",
           "table": "public.user_role_entity",
           "referenced_table": "",
-          "columns": [
-            "id"
-          ]
+          "columns": ["id"]
         }
       ]
     }
@@ -330,53 +290,37 @@
   "relations": [
     {
       "table": "public.organization_entity",
-      "columns": [
-        "parent_id"
-      ],
+      "columns": ["parent_id"],
       "cardinality": "zero_or_more",
       "parent_table": "public.organization_entity",
-      "parent_columns": [
-        "id"
-      ],
+      "parent_columns": ["id"],
       "parent_cardinality": "zero_or_one",
       "def": "FOREIGN KEY (parent_id) REFERENCES organization_entity(id) ON UPDATE CASCADE ON DELETE SET NULL"
     },
     {
       "table": "public.contact_entity",
-      "columns": [
-        "organization_id"
-      ],
+      "columns": ["organization_id"],
       "cardinality": "zero_or_more",
       "parent_table": "public.organization_entity",
-      "parent_columns": [
-        "id"
-      ],
+      "parent_columns": ["id"],
       "parent_cardinality": "exactly_one",
       "def": "FOREIGN KEY (organization_id) REFERENCES organization_entity(id) ON UPDATE CASCADE"
     },
     {
       "table": "public.user_role_entity",
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "cardinality": "zero_or_more",
       "parent_table": "public.user_entity",
-      "parent_columns": [
-        "id"
-      ],
+      "parent_columns": ["id"],
       "parent_cardinality": "exactly_one",
       "def": "FOREIGN KEY (user_id) REFERENCES user_entity(id) ON UPDATE CASCADE"
     },
     {
       "table": "public.user_role_entity",
-      "columns": [
-        "organization_id"
-      ],
+      "columns": ["organization_id"],
       "cardinality": "zero_or_more",
       "parent_table": "public.organization_entity",
-      "parent_columns": [
-        "id"
-      ],
+      "parent_columns": ["id"],
       "parent_cardinality": "exactly_one",
       "def": "FOREIGN KEY (organization_id) REFERENCES organization_entity(id) ON UPDATE CASCADE"
     }
@@ -386,10 +330,7 @@
     "database_version": "PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit",
     "meta": {
       "current_schema": "public",
-      "search_paths": [
-        "test",
-        "public"
-      ],
+      "search_paths": ["test", "public"],
       "dict": {
         "Functions": "Stored procedures and functions"
       }

--- a/docs/DependencyGraphForTest.md
+++ b/docs/DependencyGraphForTest.md
@@ -1,7 +1,9 @@
-```mermaid
-graph TD
-  RootTestModule-->PassportModule
-RootTestModule-->ContactsModule
-ContactsModule-->MikroOrmModule
-RootTestModule-->OrganizationsModule
-```
+
+  ```mermaid
+  graph TD
+    RootTestModule-->PassportModule
+  RootTestModule-->ContactsModule
+  ContactsModule-->MikroOrmModule
+  RootTestModule-->OrganizationsModule
+  ```
+  

--- a/eslint_rules/src/rules/EntityUse.ts
+++ b/eslint_rules/src/rules/EntityUse.ts
@@ -10,7 +10,8 @@ function checkEntityFilename(node: TSESTree.Node, context: Context): void {
   if (
     !context.filename.includes("service") &&
     !context.filename.includes("entity") &&
-    !context.filename.includes("repo")
+    !context.filename.includes("repo") &&
+    !context.filename.includes("spec")
   ) {
     context.report({
       messageId: "noEntityAccessOutsideServices",

--- a/grassroots-backend/openAPI.json
+++ b/grassroots-backend/openAPI.json
@@ -20,6 +20,10 @@
           "organization": {
             "$ref": "#/components/schemas/OrganizationDTO"
           },
+          "organizationId": {
+            "minimum": 1,
+            "type": "number"
+          },
           "phoneNumber": {
             "type": "string"
           }
@@ -30,6 +34,7 @@
           "firstName",
           "lastName",
           "organization",
+          "organizationId",
           "phoneNumber"
         ],
         "type": "object"

--- a/grassroots-backend/package-lock.json
+++ b/grassroots-backend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
+        "@casl/ability": "^6.7.3",
         "@mikro-orm/core": "^6.4.15",
         "@mikro-orm/nestjs": "^6.1.1",
         "@mikro-orm/postgresql": "^6.4.15",
@@ -256,6 +257,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@casl/ability": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
+      "integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
     "node_modules/@colors/colors": {
@@ -2292,6 +2305,41 @@
     "node_modules/@types/validator": {
       "version": "13.15.0",
       "license": "MIT"
+    },
+    "node_modules/@ucast/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+      "integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+      "integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.4.0.tgz",
+      "integrity": "sha512-vR9RJ3BHlkI3RfKJIZFdVktxWvBCQRiSTeJSWN9NPxP5YJkpfXvcBWAMLwvyJx4HbB+qib5/AlSDEmQiuQyx2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.0",

--- a/grassroots-backend/package.json
+++ b/grassroots-backend/package.json
@@ -17,6 +17,7 @@
     "test:tstyche": "npx tstyche"
   },
   "dependencies": {
+    "@casl/ability": "^6.7.3",
     "@mikro-orm/core": "^6.4.15",
     "@mikro-orm/nestjs": "^6.1.1",
     "@mikro-orm/postgresql": "^6.4.15",

--- a/grassroots-backend/src/FormattedMetadata.gen.ts
+++ b/grassroots-backend/src/FormattedMetadata.gen.ts
@@ -89,6 +89,11 @@ export default async () => {
                 type: () =>
                   t["./grassroots-shared/Organization.dto"].OrganizationDTO,
               },
+              organizationId: {
+                required: true,
+                type: () => Number,
+                minimum: 1,
+              },
               phoneNumber: { required: true, type: () => String },
             },
             ContactsDTO: {

--- a/grassroots-backend/src/auth/CASLIntegration.ts
+++ b/grassroots-backend/src/auth/CASLIntegration.ts
@@ -1,0 +1,83 @@
+import { MongoQuery } from "@casl/ability";
+import { AbilityQuery, rulesToQuery } from "@casl/ability/extra";
+import { FilterQuery } from "@mikro-orm/core";
+import { AppAbility, CASLAction } from "../grassroots-shared/Permission";
+import { CASLSubjects } from "@shared/CASLSubjects";
+
+// Pulled from MikroORM's GroupOperator / QueryOperator, which are enums, and we can't easily extract a list of their keys.
+const OPERATORS = [
+  "$and",
+  "$or",
+  "$eq",
+  "$ne",
+  "$in",
+  "$nin",
+  "$not",
+  "$none",
+  "$some",
+  "$every",
+  "$gt",
+  "$gte",
+  "$lt",
+  "$lte",
+  "$like",
+  "$re",
+  "$ilike",
+  "$fulltext",
+  "$overlap",
+  "$contains",
+  "$contained",
+  "$exists",
+  "$hasKey",
+  "$hasKeys",
+  "$hasSomeKeys",
+] as const;
+
+const OPERATORS_SET = new Set<string>(OPERATORS);
+
+// Based on https://casl.js.org/v4/en/advanced/ability-to-database-query.
+// This is mostly a silly cast currently. As we run into failure cases,
+// we'll need to handle them appropriately.
+function mapOperators<T>(query: AbilityQuery<MongoQuery>): FilterQuery<T> {
+  JSON.parse(JSON.stringify(query), function keyToSymbol<
+    TValue,
+  >(key: string, value: TValue): TValue {
+    if (key.startsWith("$")) {
+      if (!OPERATORS_SET.has(key)) {
+        throw new Error(`Invalid operator in CASL rule: ${key}`);
+      }
+    }
+
+    return value;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return query as FilterQuery<T>;
+}
+
+// Returns null if access is never appropriate.
+export function getAccessRules<
+  T extends {
+    new (...args: unknown[]): unknown;
+    __caslSubjectTypeStatic: keyof CASLSubjects;
+  },
+  TInstance = InstanceType<T>,
+>(
+  ability: AppAbility,
+  action: CASLAction,
+  type: T,
+): FilterQuery<TInstance> | null {
+  const query: AbilityQuery<MongoQuery> | null = rulesToQuery<
+    AppAbility,
+    MongoQuery
+  >(ability, action, type.__caslSubjectTypeStatic, (rule) => {
+    if (rule.conditions === undefined) {
+      throw new Error("CASL rule with null conditions");
+    }
+    return rule.inverted ? { $not: rule.conditions } : rule.conditions;
+  });
+  if (query === null) {
+    return null;
+  }
+  return mapOperators<TInstance>(query);
+}

--- a/grassroots-backend/src/contacts/entities/Contact.entity.ts
+++ b/grassroots-backend/src/contacts/entities/Contact.entity.ts
@@ -1,6 +1,7 @@
 import {
   Entity,
   ManyToOne,
+  OptionalProps,
   PrimaryKey,
   Property,
   Rel,
@@ -15,6 +16,8 @@ import { OrganizationEntity } from "../../organizations/Organization.entity";
 export class ContactEntity extends createEntityBase<"Contact", ContactDTO>(
   "Contact",
 ) {
+  [OptionalProps]?: "organizationId";
+
   @PrimaryKey()
   id!: number;
 
@@ -31,8 +34,12 @@ export class ContactEntity extends createEntityBase<"Contact", ContactDTO>(
   @Property()
   phoneNumber!: string;
 
-  @ManyToOne(() => OrganizationEntity)
+  @ManyToOne(() => OrganizationEntity, { joinColumn: "organizationId" })
   organization!: Rel<OrganizationEntity>;
+
+  get organizationId(): number {
+    return this.organization.id;
+  }
 
   toDTO(): ContactDTO {
     return ContactDTO.from({
@@ -42,6 +49,7 @@ export class ContactEntity extends createEntityBase<"Contact", ContactDTO>(
       lastName: this.lastName,
       phoneNumber: this.phoneNumber,
       organization: this.organization.toDTO(),
+      organizationId: this.organizationId,
     });
   }
 }

--- a/grassroots-backend/src/grassroots-shared/CASLSubjects/CASLSubjects.backend.ts
+++ b/grassroots-backend/src/grassroots-shared/CASLSubjects/CASLSubjects.backend.ts
@@ -1,0 +1,16 @@
+import { ContactEntity } from "../../contacts/entities/Contact.entity";
+import { UserEntity } from "../../users/User.entity";
+import { CommonProps } from "../util/TypeUtils";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SUBJECTS = [UserEntity, ContactEntity] as const;
+
+type SubjectConstructors = (typeof SUBJECTS)[number];
+
+// CommonProps is stripping out the subject type right now...
+export type CASLSubjects = {
+  [SubjectConstructor in SubjectConstructors as SubjectConstructor["__caslSubjectTypeStatic"]]: CommonProps<
+    InstanceType<SubjectConstructor>,
+    ReturnType<InstanceType<SubjectConstructor>["toDTO"]>
+  > & { __caslSubjectType: SubjectConstructor["__caslSubjectTypeStatic"] };
+};

--- a/grassroots-backend/src/grassroots-shared/CASLSubjects/CASLSubjects.frontend.ts
+++ b/grassroots-backend/src/grassroots-shared/CASLSubjects/CASLSubjects.frontend.ts
@@ -1,0 +1,16 @@
+// The backend and frontend need different notions of CASL Subjects, since the frontend
+// doesn't know about entities. This is used on the frontend instead of the definition
+// provided in the backend.
+
+import { ContactDTO } from "../Contact.dto";
+import { UserDTO } from "../User.dto";
+import { PropsOf } from "../util/TypeUtils";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SUBJECTS = [UserDTO, ContactDTO] as const;
+
+export type CASLSubjects = {
+  [T in (typeof SUBJECTS)[number] as T["__caslSubjectTypeStatic"]]: PropsOf<
+    InstanceType<T>
+  > & { __caslSubjectType: T["__caslSubjectTypeStatic"] };
+};

--- a/grassroots-backend/src/grassroots-shared/Contact.dto.ts
+++ b/grassroots-backend/src/grassroots-shared/Contact.dto.ts
@@ -33,6 +33,10 @@ export class ContactDTO extends createDTOBase("Contact") {
   @ValidateNested()
   organization!: OrganizationDTO;
 
+  @IsInt()
+  @Min(1)
+  organizationId!: number;
+
   @IsPhoneNumber("CA")
   phoneNumber!: string;
 }

--- a/grassroots-backend/src/grassroots-shared/OpenAPI.gen.ts
+++ b/grassroots-backend/src/grassroots-shared/OpenAPI.gen.ts
@@ -330,6 +330,7 @@ export interface components {
       id: number;
       lastName: string;
       organization: components["schemas"]["OrganizationDTO"];
+      organizationId: number;
       phoneNumber: string;
     };
     ContactSearchRequestDTO: {

--- a/grassroots-backend/src/grassroots-shared/Permission.ts
+++ b/grassroots-backend/src/grassroots-shared/Permission.ts
@@ -1,0 +1,172 @@
+import {
+  AbilityBuilder,
+  createMongoAbility,
+  MongoAbility,
+  MongoQuery,
+  subject,
+} from "@casl/ability";
+import { UserEntity } from "../users/User.entity";
+import { ContactEntity } from "../contacts/entities/Contact.entity";
+import { CommonProps } from "./util/TypeUtils";
+import { AbilityQuery, rulesToQuery } from "@casl/ability/extra";
+import { FilterQuery } from "@mikro-orm/core";
+
+export enum Permission {
+  VIEW_CONTACTS = "VIEW_CONTACTS",
+  MANAGE_CONTACTS = "MANAGE_CONTACTS",
+  MANAGE_USERS = "MANAGE_USERS",
+}
+
+type Action = "read" | "edit";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SUBJECTS = [UserEntity, ContactEntity] as const;
+
+type SubjectConstructors = (typeof SUBJECTS)[number];
+
+// CommonProps is stripping out the subject type right now...
+export type CASLSubjects = {
+  [SubjectConstructor in SubjectConstructors as SubjectConstructor["__caslSubjectTypeStatic"]]: CommonProps<
+    InstanceType<SubjectConstructor>,
+    ReturnType<InstanceType<SubjectConstructor>["toDTO"]>
+  > & { __caslSubjectType: SubjectConstructor["__caslSubjectTypeStatic"] };
+};
+
+export function buildCASLSubject<K extends keyof CASLSubjects>(
+  k: K,
+  x: Omit<CASLSubjects[K], "__caslSubjectType">,
+): CASLSubjects[K] {
+  // Type inference isn't quite clever enough here.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return {
+    ...x,
+    __caslSubjectType: k,
+  } as CASLSubjects[K];
+}
+
+type CASLSubjectUnion = CASLSubjects[keyof CASLSubjects];
+
+// MongoAbility needs to know both about the string types (keyof CASLSubjects) and the object structure (CASLSubjects).
+// It maps from strings to object types via `detectSubjectType` below.
+// TODO: don't export once we have better tests.
+export type AppAbility = MongoAbility<
+  [Action, keyof CASLSubjects | CASLSubjectUnion]
+>;
+
+// CASL uses "can" both to define abilities and query them.
+// Note that this is the method for querying.
+export function can(
+  ability: AppAbility,
+  action: Action,
+  type: keyof CASLSubjects,
+  object: CASLSubjectUnion,
+): boolean {
+  return ability.can(action, subject(type, object));
+}
+
+// We need this strongly typed, so this is copied from MikroORM's QueryOperator.
+const OPERATORS = [
+  "$and",
+  "$or",
+  "$eq",
+  "$ne",
+  "$in",
+  "$nin",
+  "$not",
+  "$none",
+  "$some",
+  "$every",
+  "$gt",
+  "$gte",
+  "$lt",
+  "$lte",
+  "$like",
+  "$re",
+  "$ilike",
+  "$fulltext",
+  "$overlap",
+  "$contains",
+  "$contained",
+  "$exists",
+  "$hasKey",
+  "$hasKeys",
+  "$hasSomeKeys",
+] as const;
+
+const OPERATORS_SET = new Set<string>(OPERATORS);
+
+// Based on https://casl.js.org/v4/en/advanced/ability-to-database-query.
+// This is mostly a silly cast currently. As we run into failure cases,
+// we'll need to handle them appropriately.
+function mapOperators<T>(query: AbilityQuery<MongoQuery>): FilterQuery<T> {
+  JSON.parse(JSON.stringify(query), function keyToSymbol<
+    TValue,
+  >(key: string, value: TValue): TValue {
+    if (key.startsWith("$")) {
+      if (!OPERATORS_SET.has(key)) {
+        throw new Error(`Invalid operator in CASL rule: ${key}`);
+      }
+    }
+
+    return value;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return query as FilterQuery<T>;
+}
+
+// Returns null if access is never appropriate.
+export function getAccessRules<
+  T extends {
+    new (...args: unknown[]): unknown;
+    __caslSubjectTypeStatic: keyof CASLSubjects;
+  },
+  TInstance = InstanceType<T>,
+>(ability: AppAbility, action: Action, type: T): FilterQuery<TInstance> | null {
+  const query: AbilityQuery<MongoQuery> | null = rulesToQuery<
+    AppAbility,
+    MongoQuery
+  >(ability, action, type.__caslSubjectTypeStatic, (rule) => {
+    if (rule.conditions === undefined) {
+      throw new Error("CASL rule with null conditions");
+    }
+    return rule.inverted ? { $not: rule.conditions } : rule.conditions;
+  });
+  if (query === null) {
+    return null;
+  }
+  return mapOperators<TInstance>(query);
+}
+
+export function permissionsToCaslAbilities(
+  user: CASLSubjects["User"],
+  activeOrganizationId: number,
+  permissions: Set<keyof typeof Permission>,
+): AppAbility {
+  const { can, cannot, build } = new AbilityBuilder<AppAbility>(
+    createMongoAbility,
+  );
+  void cannot;
+  can("read", "User", { id: user.id });
+
+  const PERMISSIONS_TO_CASL_RULES: Record<keyof typeof Permission, () => void> =
+    {
+      VIEW_CONTACTS: () => {
+        can("read", "Contact", { organizationId: activeOrganizationId });
+      },
+      MANAGE_CONTACTS: () => {
+        can("edit", "Contact");
+      },
+      MANAGE_USERS: () => {
+        can("edit", "User");
+      },
+    };
+
+  for (const permission of permissions) {
+    PERMISSIONS_TO_CASL_RULES[permission]();
+  }
+
+  return build({
+    detectSubjectType: (obj: CASLSubjectUnion) => obj.__caslSubjectType,
+  });
+}

--- a/grassroots-backend/src/grassroots-shared/util/AsProps.ts
+++ b/grassroots-backend/src/grassroots-shared/util/AsProps.ts
@@ -1,0 +1,6 @@
+import { PropsOf } from "./TypeUtils";
+
+export function asProps<T>(t: T): PropsOf<T> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return t as PropsOf<T>;
+}

--- a/grassroots-backend/src/grassroots-shared/util/CreateDTOBase.ts
+++ b/grassroots-backend/src/grassroots-shared/util/CreateDTOBase.ts
@@ -41,7 +41,7 @@ export function createDTOBase<TBrand extends string>(brand: TBrand) {
     // between entities or DTOs, or we get some type collicions.
     readonly __DTOBrand!: `${TBrand}DTO`;
     // Used for CASL to identify object types.
-    readonly __caslSubjectType: string = brand;
+    readonly __caslSubjectType: TBrand = brand;
 
     static from<T extends Branded>(
       // The this parameter must be named "this", and is magically populated with the class constructor.

--- a/grassroots-backend/src/grassroots-shared/util/CreateDTOBase.ts
+++ b/grassroots-backend/src/grassroots-shared/util/CreateDTOBase.ts
@@ -38,10 +38,11 @@ export interface FetchResponse<T, E> {
 export function createDTOBase<TBrand extends string>(brand: TBrand) {
   abstract class Branded {
     // We need different names for our branding types
-    // between entities or DTOs, or we get some type collicions.
+    // between entities or DTOs, or we get some type collisions.
     readonly __DTOBrand!: `${TBrand}DTO`;
     // Used for CASL to identify object types.
     readonly __caslSubjectType: TBrand = brand;
+    static readonly __caslSubjectTypeStatic: TBrand = brand;
 
     static from<T extends Branded>(
       // The this parameter must be named "this", and is magically populated with the class constructor.
@@ -67,5 +68,6 @@ export function createDTOBase<TBrand extends string>(brand: TBrand) {
       );
     }
   }
+
   return Branded;
 }

--- a/grassroots-backend/src/grassroots-shared/util/TypeUtils.ts
+++ b/grassroots-backend/src/grassroots-shared/util/TypeUtils.ts
@@ -223,7 +223,7 @@ function TestPropsOf(): void {
 export type CommonProps<A, B, AProps = PropsOf<A>, BProps = PropsOf<B>> = {
   // We can't iterate AProps & BProps, as that loses optionality.
   [k in keyof AProps as k extends keyof BProps
-    ? If<IsAssignableTo<AProps[k], BProps[k]>, k, never>
+    ? If<Equals<AProps[k], BProps[k]>, k, never>
     : never]: AProps[k];
 };
 
@@ -235,6 +235,8 @@ type TestCommonProps = Assert<
         a: number;
         firstOnly: string;
         notMatching: string;
+        nestedNotMatching: { x: string };
+        nestedPartialMatch: { y: number; x: string };
         optionalInAOnly?: string;
         optionalInBoth?: string;
         excluded(): () => void;
@@ -243,6 +245,8 @@ type TestCommonProps = Assert<
         a: number;
         secondOnly: string;
         notMatching: number;
+        nestedNotMatching: { y: number };
+        nestedPartialMatch: { y: number };
         optionalInAOnly: string;
         optionalInBoth?: string;
         excluded(): () => void;

--- a/grassroots-backend/src/migrations/.snapshot-grassroots.json
+++ b/grassroots-backend/src/migrations/.snapshot-grassroots.json
@@ -118,8 +118,8 @@
           "length": 255,
           "mappedType": "string"
         },
-        "organization_id": {
-          "name": "organization_id",
+        "organizationId": {
+          "name": "organizationId",
           "type": "int",
           "unsigned": false,
           "autoincrement": false,
@@ -154,10 +154,10 @@
       ],
       "checks": [],
       "foreignKeys": {
-        "contact_entity_organization_id_foreign": {
-          "constraintName": "contact_entity_organization_id_foreign",
+        "contact_entity_organizationId_foreign": {
+          "constraintName": "contact_entity_organizationId_foreign",
           "columnNames": [
-            "organization_id"
+            "organizationId"
           ],
           "localTableName": "public.contact_entity",
           "referencedColumnNames": [

--- a/grassroots-backend/src/migrations/Migration20250804173939.ts
+++ b/grassroots-backend/src/migrations/Migration20250804173939.ts
@@ -1,0 +1,19 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250804173939 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "contact_entity" drop constraint "contact_entity_organization_id_foreign";`);
+
+    this.addSql(`alter table "contact_entity" rename column "organization_id" to "organizationId";`);
+    this.addSql(`alter table "contact_entity" add constraint "contact_entity_organizationId_foreign" foreign key ("organizationId") references "organization_entity" ("id") on update cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "contact_entity" drop constraint "contact_entity_organizationId_foreign";`);
+
+    this.addSql(`alter table "contact_entity" rename column "organizationId" to "organization_id";`);
+    this.addSql(`alter table "contact_entity" add constraint "contact_entity_organization_id_foreign" foreign key ("organization_id") references "organization_entity" ("id") on update cascade;`);
+  }
+
+}

--- a/grassroots-backend/src/organizations/Organizations.service.ts
+++ b/grassroots-backend/src/organizations/Organizations.service.ts
@@ -7,6 +7,7 @@ import {
 } from "../grassroots-shared/Organization.dto";
 import { EntityManager } from "@mikro-orm/core";
 import { OrganizationRepository } from "./Organization.repo";
+import { asProps } from "../grassroots-shared/util/AsProps";
 
 @Injectable()
 export class OrganizationsService {
@@ -20,7 +21,7 @@ export class OrganizationsService {
     organization: CreateOrganizationNoParentRequestDTO,
     parentID: number | null,
   ): Promise<OrganizationEntity> {
-    const newOrganization = this.repo.create(organization);
+    const newOrganization = this.repo.create(asProps(organization));
 
     if (parentID != null) {
       const parent = await this.repo.findOne({

--- a/grassroots-backend/src/testing/CaslSubjects.spec.ts
+++ b/grassroots-backend/src/testing/CaslSubjects.spec.ts
@@ -3,7 +3,6 @@ import {
   can,
   buildCASLSubject,
   permissionsToCaslAbilities,
-  getAccessRules,
   AppAbility,
 } from "../grassroots-shared/Permission";
 import { UserDTO } from "../grassroots-shared/User.dto";
@@ -13,6 +12,7 @@ import { OrganizationDTO } from "../grassroots-shared/Organization.dto";
 import { ContactEntity } from "../contacts/entities/Contact.entity";
 import { OrganizationEntity } from "../organizations/Organization.entity";
 import { AbilityBuilder, createMongoAbility } from "@casl/ability";
+import { getAccessRules } from "../auth/CASLIntegration";
 
 const ORG_WITH_PERMISSIONS_ID = 10;
 

--- a/grassroots-backend/src/testing/CaslSubjects.spec.ts
+++ b/grassroots-backend/src/testing/CaslSubjects.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  can,
+  buildCASLSubject,
+  permissionsToCaslAbilities,
+  getAccessRules,
+  AppAbility,
+} from "../grassroots-shared/Permission";
+import { UserDTO } from "../grassroots-shared/User.dto";
+import mikroORMConfig from "../mikro-orm.config";
+import { MikroORM } from "@mikro-orm/core";
+import { OrganizationDTO } from "../grassroots-shared/Organization.dto";
+import { ContactEntity } from "../contacts/entities/Contact.entity";
+import { OrganizationEntity } from "../organizations/Organization.entity";
+import { AbilityBuilder, createMongoAbility } from "@casl/ability";
+
+const ORG_WITH_PERMISSIONS_ID = 10;
+
+const ORGANIZATION = OrganizationDTO.from({
+  id: ORG_WITH_PERMISSIONS_ID,
+  name: "Test",
+});
+
+describe("permissionsToCaslAbilities", () => {
+  const contact = buildCASLSubject("Contact", {
+    id: 1,
+    email: "a@a.com",
+    firstName: "d",
+    lastName: "d",
+    phoneNumber: "226-888-8888",
+    organizationId: ORGANIZATION.id,
+  });
+
+  const user = UserDTO.from({
+    id: "Foo",
+  });
+
+  it("shouldn't allow someone with no permissions to view contacts", () => {
+    const ability = permissionsToCaslAbilities(
+      user,
+      ORG_WITH_PERMISSIONS_ID,
+      new Set([]),
+    );
+    expect(can(ability, "read", "Contact", contact)).toBe(false);
+  });
+
+  it("should allow someone with permissions to view contacts", () => {
+    const ability = permissionsToCaslAbilities(
+      user,
+      ORG_WITH_PERMISSIONS_ID,
+      new Set(["VIEW_CONTACTS"]),
+    );
+    expect(can(ability, "read", "Contact", contact)).toBe(true);
+  });
+
+  it("shouldn't allow someone with permissions to view contacts outside their active org", () => {
+    const ability = permissionsToCaslAbilities(
+      user,
+      // Pick an org ID other than the one with permissions.
+      ORG_WITH_PERMISSIONS_ID + 1,
+      new Set(["VIEW_CONTACTS"]),
+    );
+    expect(can(ability, "read", "Contact", contact)).toBe(false);
+  });
+
+  it("should allow someone with no permissions to view only their own user", () => {
+    const ability = permissionsToCaslAbilities(
+      user,
+      ORG_WITH_PERMISSIONS_ID,
+      new Set([]),
+    );
+    expect(can(ability, "read", "User", user)).toBe(true);
+    user.id += "idIsNoLongerEqual";
+    expect(can(ability, "read", "User", user)).toBe(false);
+  });
+
+  it("Should work on the database", async () => {
+    const orm = await MikroORM.init(mikroORMConfig);
+    const em = orm.em.fork();
+    await em.begin();
+
+    const validOrg = em.create(OrganizationEntity, {
+      name: "validOrg",
+    });
+    const invalidOrg = em.create(OrganizationEntity, {
+      name: "invalidOrg",
+    });
+    await em.flush();
+
+    const ability = permissionsToCaslAbilities(
+      user,
+      validOrg.id,
+      new Set(["VIEW_CONTACTS"]),
+    );
+
+    const rules = getAccessRules(ability, "read", ContactEntity);
+    if (rules === null) {
+      throw new Error("Should have access to some contacts");
+    }
+
+    em.create(ContactEntity, {
+      email: "valid@valid.com",
+      firstName: "",
+      lastName: "",
+      phoneNumber: "",
+      organization: validOrg,
+    });
+    em.create(ContactEntity, {
+      email: "invalid@invalid.com",
+      firstName: "",
+      lastName: "",
+      phoneNumber: "",
+      organization: invalidOrg,
+    });
+    const validContacts = await em.findAll(ContactEntity, { where: rules });
+    expect(validContacts.length).toBe(1);
+    expect(validContacts[0]?.email).toBe("valid@valid.com");
+    await em.rollback();
+  });
+
+  it("Should support inverted database queries", async () => {
+    const orm = await MikroORM.init(mikroORMConfig);
+    const em = orm.em.fork();
+    await em.begin();
+    const validOrg = em.create(OrganizationEntity, {
+      name: "validOrg",
+    });
+
+    const { can, cannot, build } = new AbilityBuilder<AppAbility>(
+      createMongoAbility,
+    );
+    can("read", "Contact");
+    cannot("read", "Contact", { email: "invalid@invalid.com" });
+    const ability = build();
+
+    const rules = getAccessRules(ability, "read", ContactEntity);
+    if (rules === null) {
+      throw new Error("Should have access to some contacts");
+    }
+
+    em.create(ContactEntity, {
+      email: "valid@valid.com",
+      firstName: "",
+      lastName: "",
+      phoneNumber: "",
+      organization: validOrg,
+    });
+    em.create(ContactEntity, {
+      email: "invalid@invalid.com",
+      firstName: "",
+      lastName: "",
+      phoneNumber: "",
+      organization: validOrg,
+    });
+    const validContacts = await em.findAll(ContactEntity, { where: rules });
+    expect(validContacts.length).toBe(1);
+    expect(validContacts[0]?.email).toBe("valid@valid.com");
+    await em.rollback();
+  });
+});

--- a/grassroots-backend/src/util/CreateEntityBase.ts
+++ b/grassroots-backend/src/util/CreateEntityBase.ts
@@ -19,8 +19,10 @@ export function createEntityBase<TBrand extends string, TDTO>(brand: TBrand) {
     // between entities or DTOs, or we get some type collicions.
     readonly __entityBrand!: Opt<`${TBrand}Entity`>;
     // Used for CASL to identify object types.
+
     @Property({ persist: false })
-    readonly __caslSubjectType: Opt<string> = brand;
+    readonly __caslSubjectType: Opt<TBrand> = brand;
+    static readonly __caslSubjectTypeStatic: TBrand = brand;
     abstract toDTO(): TDTO;
   }
   return Branded;

--- a/grassroots-backend/tsconfig.json
+++ b/grassroots-backend/tsconfig.json
@@ -11,7 +11,12 @@
     "sourceMap": true,
     "outDir": "./dist",
     "incremental": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@shared/CASLSubjects": [
+        "./src/grassroots-shared/CASLSubjects/CASLSubjects.backend.ts"
+      ]
+    }
   },
   "exclude": ["src/testing/typetests/**"]
 }

--- a/grassroots-frontend/package-lock.json
+++ b/grassroots-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "grassroots-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@casl/ability": "^6.7.3",
         "@faker-js/faker": "^9.9.0",
         "@mantine/core": "^7.17.4",
         "@mantine/hooks": "^7.17.4",
@@ -340,6 +341,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@casl/ability": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
+      "integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1756,6 +1769,41 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.0.tgz",
       "integrity": "sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==",
       "license": "MIT"
+    },
+    "node_modules/@ucast/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+      "integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+      "integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.4.0.tgz",
+      "integrity": "sha512-vR9RJ3BHlkI3RfKJIZFdVktxWvBCQRiSTeJSWN9NPxP5YJkpfXvcBWAMLwvyJx4HbB+qib5/AlSDEmQiuQyx2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
+      }
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.9.0",

--- a/grassroots-frontend/package.json
+++ b/grassroots-frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@casl/ability": "^6.7.3",
     "@faker-js/faker": "^9.9.0",
     "@mantine/core": "^7.17.4",
     "@mantine/hooks": "^7.17.4",

--- a/grassroots-frontend/src/hooks/useContactSearch.ts
+++ b/grassroots-frontend/src/hooks/useContactSearch.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { DefinedUseQueryResult, useQuery } from "@tanstack/react-query";
 import { grassrootsAPI } from "../GrassRootsAPI";
 import {
   PaginatedContactResponseDTO,
@@ -7,11 +7,12 @@ import {
 
 export function useContactSearch(
   searchParams: PaginatedContactSearchRequestDTO,
-): UseQueryResult<PaginatedContactResponseDTO> {
+): DefinedUseQueryResult<PaginatedContactResponseDTO> {
   return useQuery<PaginatedContactResponseDTO>({
     queryKey: ["contacts", searchParams],
     staleTime: 60 * 1000,
     retry: 1,
+    initialData: PaginatedContactResponseDTO.empty(),
     // If the user hits the next button, keep showing the prior data until new data is ready.
     placeholderData: (priorData) =>
       priorData ?? PaginatedContactResponseDTO.empty(),

--- a/grassroots-frontend/src/routes/Search.tsx
+++ b/grassroots-frontend/src/routes/Search.tsx
@@ -8,7 +8,6 @@ import { RoutedLink } from "../components/RoutedLink";
 import { transformingClassValidatorResolver } from "../TransformingClassValidatorResolver";
 import {
   ContactSearchRequestDTO,
-  PaginatedContactResponseDTO,
   PaginatedContactSearchRequestDTO,
 } from "../grassroots-shared/Contact.dto";
 
@@ -38,8 +37,7 @@ function Search(): JSX.Element {
     },
   });
 
-  const useContactSearchResults =
-    useContactSearch(searchParams).data ?? PaginatedContactResponseDTO.empty();
+  const useContactSearchResults = useContactSearch(searchParams).data;
 
   return (
     <>

--- a/grassroots-frontend/src/routes/SharedSearch.tsx
+++ b/grassroots-frontend/src/routes/SharedSearch.tsx
@@ -4,7 +4,6 @@ import { useContactSearch } from "../hooks/useContactSearch";
 import { PaginatedContacts } from "../components/PaginatedContacts";
 import {
   ContactSearchRequestDTO,
-  PaginatedContactResponseDTO,
   PaginatedContactSearchRequestDTO,
 } from "../grassroots-shared/Contact.dto";
 import { cast } from "../grassroots-shared/util/Cast";
@@ -24,7 +23,7 @@ function SharedSearch(): JSX.Element {
   const search = Route.useSearch();
   const [rowsToSkip, setRowsToSkip] = useState<number>(0);
 
-  let { data: paginatedContactResponse } = useContactSearch(
+  const { data: paginatedContactResponse } = useContactSearch(
     PaginatedContactSearchRequestDTO.from({
       contact: search,
       paginated: {
@@ -33,8 +32,6 @@ function SharedSearch(): JSX.Element {
       },
     }),
   );
-  paginatedContactResponse =
-    paginatedContactResponse ?? PaginatedContactResponseDTO.empty();
   return (
     <PaginatedContacts
       paginatedContactResponse={paginatedContactResponse}

--- a/grassroots-frontend/src/routes/Users.tsx
+++ b/grassroots-frontend/src/routes/Users.tsx
@@ -12,10 +12,11 @@ export const Route = createFileRoute("/Users")({
 function Users(): JSX.Element {
   const { data: users } = useQuery<UsersDTO>({
     queryKey: ["users"],
+    initialData: UsersDTO.from({ users: [] }),
     queryFn: async () => {
       const result = await grassrootsAPI.GET("/users", {});
       return UsersDTO.fromFetchOrThrow(result);
     },
   });
-  return <div>{(users?.users ?? []).map((x) => UserRow({ user: x }))}</div>;
+  return <div>{users.users.map((x) => UserRow({ user: x }))}</div>;
 }

--- a/grassroots-frontend/tsconfig.json
+++ b/grassroots-frontend/tsconfig.json
@@ -18,8 +18,12 @@
     "experimentalDecorators": true,
     "paths": {
       "@nestjs/common": ["./src/NestCommonShim"],
-      "@nestjs/swagger": ["./src/NestCommonShim"]
+      "@nestjs/swagger": ["./src/NestCommonShim"],
+      "@shared/CASLSubjects": [
+        "./src/grassroots-shared/CASLSubjects/CASLSubjects.frontend.ts"
+      ]
     }
   },
-  "include": ["src", "grassroots-shared", "vite.config.ts"]
+  "include": ["src", "grassroots-shared", "vite.config.ts"],
+  "exclude": ["src/grassroots-shared/CASLSubjects/CASLSubjects.backend.ts"]
 }

--- a/grassroots-frontend/vite.config.ts
+++ b/grassroots-frontend/vite.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     alias: {
       "@nestjs/common": path.resolve(__dirname, "./src/NestCommonShim"),
       "@nestjs/swagger": path.resolve(__dirname, "./src/NestCommonShim"),
+      "@shared/CASLSubjects": path.resolve(
+        __dirname,
+        "./src/grassroots-shared/CASLSubjects/CASLSubjects.frontend.ts",
+      ),
     },
   },
 });


### PR DESCRIPTION
This implements CASL authorization, but doesn't use it, or integrate it at the db level.
The framework for using it with mikroORM is landed, but only used in a test showing off roughly how it works.

Followup patches will integrate this into our repository and baseentitiy classes, and ensure this is used by our services.