### PR TITLE
build & run in Dockerfile, dev override in compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=23.0.0
-FROM node:${NODE_VERSION}
+FROM --platform=linux/amd64 node:${NODE_VERSION}
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -28,7 +28,8 @@ RUN wget -qO- https://twilio-cli-prod.s3.amazonaws.com/twilio_pub.asc | apt-key 
   echo 'deb https://twilio-cli-prod.s3.amazonaws.com/apt/ /' | tee /etc/apt/sources.list.d/twilio.list && \
   apt-get update && \
   apt-get install -y sudo && \
-  apt install -y twilio
+  apt install -y twilio && \
+  apt-get clean
 
 # First remove the node user to avoid uid/gid conflicts, then we create our user.
 RUN deluser node --remove-home \
@@ -51,6 +52,7 @@ USER ${UNAME}
 
 RUN pnpm add turbo --global
 RUN pnpm install --frozen-lockfile
+RUN turbo build
 
 # Vite
 EXPOSE 5173
@@ -61,4 +63,4 @@ EXPOSE 3000
 # we'd want to:
 # CMD ["pnpm", "run", "dev"]
 
-CMD ["sleep", "infinity"]
+CMD ["pnpm", "run", "start:prod"]

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -32,6 +32,7 @@ services:
 
   grassroots_dev:
     container_name: grassroots_dev
+    command: ["sleep", "inf"]
     build: ".."
     volumes:
       - ../:/app


### PR DESCRIPTION
This change is a step towards making our Dockerfile ready for prod while retaining a nice dev experience.

Adding the `--platform=linux/amd64` is perhaps the spiciest take in here. This makes things work correctly on apple silicon (where it runs under emulation) but may not be desirable in other environments, please let me know if this breaks things for WSL or something.

`apt-get clean` removes unneeded caches from the final docker image.

The other changes make it so the default image built by our Dockerfile runs the app directly, but the compose.yaml used for local dev still sleeps forever allowing interactive development.

Note that the `turbo build` command currently doesn't work due to #271 so

## DONT MERGE THIS (yet)

Leaving it as a draft until this is fixed.