### PR TITLE
Address GPO feedback (no more last call button)

### DIFF
--- a/grassroots-backend/src/phone-canvass/PhoneCanvass.controller.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvass.controller.ts
@@ -97,6 +97,7 @@ export class PhoneCanvassController {
               if (call === undefined) {
                 return;
               }
+
               call.update(status.status, {
                 result: status.result,
                 twilioSid: callback.CallSid,

--- a/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
@@ -5,7 +5,6 @@ import {
   Observable,
   scan,
   startWith,
-  tap,
   throttleTime,
 } from "rxjs";
 import { Call } from "./Scheduler/PhoneCanvassCall.js";
@@ -195,9 +194,6 @@ export class PhoneCanvassModel {
       contacts: contactSummaries$.pipe(startWith([])),
       callsCompleted: completedCallCount$.pipe(startWith(0)),
     }).pipe(
-      tap((syncData) => {
-        console.log("syncData", JSON.stringify(syncData, null, 2));
-      }),
       map((syncData) => {
         return {
           callers: syncData.callers,

--- a/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
@@ -125,7 +125,7 @@ export class PhoneCanvassModel {
           this.#callsBySid.set(call.twilioSid, call);
         }
 
-        runPromise(call.log(), false);
+        runPromise(call.log(this.#phoneCanvassCallersModel), false);
         runPromise(call.updateContactIfNeeded(this.#entityManager), false);
 
         // When a call ends, if it was associated with a contact in the last call state, we mark them unready.
@@ -346,6 +346,12 @@ export class PhoneCanvassModel {
       );
     }
     if (callback.AnsweredBy === "human" || callback.AnsweredBy === "unknown") {
+      if (call.status === "COMPLETED") {
+        call.update("COMPLETED", {
+          answeredBy: callback.AnsweredBy,
+        });
+        return;
+      }
       const callerId = this.scheduler.getNextIdleCallerId();
       if (callerId === undefined) {
         // Uh oh, we've overcalled.

--- a/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvass.model.ts
@@ -110,12 +110,10 @@ export class PhoneCanvassModel {
           );
         } else if (call.status === "COMPLETED") {
           console.log("CALL COMPLETED");
-          console.log(call);
           if (call.callerId !== undefined) {
             const caller = this.#phoneCanvassCallersModel.getCaller(
               call.callerId,
             );
-            console.log({ caller });
             const update = caller.toUpdate();
             update.ready = "unready";
             this.#phoneCanvassCallersModel.updateCallerInternal(update);
@@ -139,6 +137,21 @@ export class PhoneCanvassModel {
           return acc;
         }, new Map<string, CallerSummary>()),
       );
+
+    callerSummariesById$.subscribe({
+      next: (callerSummariesById) => {
+        const readyCallerCount = [...callerSummariesById.values()].filter(
+          (caller) => caller.ready === "ready",
+        ).length;
+        console.log("READY CALLER COUNT", readyCallerCount);
+        this.scheduler.metricsTracker.onReadyCallerCountUpdate(
+          readyCallerCount,
+        );
+      },
+      error: (e: unknown) => {
+        throw e;
+      },
+    });
 
     const callerSummaries$ = callerSummariesById$.pipe(
       map((x) => [...x.values()]),
@@ -321,7 +334,6 @@ export class PhoneCanvassModel {
         answeredBy: callback.AnsweredBy,
         callerId,
       });
-      console.log("UPDATED CALL", call);
       return;
     }
 

--- a/grassroots-backend/src/phone-canvass/PhoneCanvass.service.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvass.service.ts
@@ -57,7 +57,7 @@ export class PhoneCanvassService {
           await this.updateModelsOnRestart();
         } catch {
           // TODO: figure out why this happens in CI.
-          console.log("Failed to update models");
+          console.log("Failed to update models on restart.");
         }
       })(),
       true,

--- a/grassroots-backend/src/phone-canvass/PhoneCanvassSimulator.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvassSimulator.ts
@@ -1,4 +1,5 @@
 import {
+  CallReadyStatus,
   CreateOrUpdatePhoneCanvassCallerDTO,
   PhoneCanvassCallerDTO,
   PhoneCanvasTwilioCallAnsweredCallbackDTO,
@@ -89,7 +90,7 @@ interface AddCallerEvent extends BaseEvent {
 interface ChangeReadyCallerEvent extends BaseEvent {
   kind: "change_ready_caller";
   index: number;
-  ready: "ready" | "unready";
+  ready: CallReadyStatus;
 }
 
 interface StatusChangeEvent extends BaseEvent {
@@ -154,7 +155,6 @@ export class PhoneCanvassSimulator {
       ready: "ready",
     });
 
-    // TODO: maybe include the "last call" state.
     /*while (this.#running) {
       await delay(callerReadyDelta());
       this.#events.next({

--- a/grassroots-backend/src/phone-canvass/PhoneCanvassSimulator.ts
+++ b/grassroots-backend/src/phone-canvass/PhoneCanvassSimulator.ts
@@ -25,7 +25,8 @@ function callerJoinDelta(): number {
   return sampleLogNormalFromCI(100, 5000);
 }
 function callerReadyDelta(): number {
-  return sampleLogNormalFromCI(1000, 10_000);
+  //return sampleLogNormalFromCI(1000, 2_000);
+  return sampleLogNormalFromCI(100, 200);
 }
 // Used when we want to model callers becoming unready.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -147,13 +148,17 @@ export class PhoneCanvassSimulator {
       ts: Date.now(),
     });
 
-    await delay(callerReadyDelta());
-    this.#events.next({
-      kind: "change_ready_caller",
-      index,
-      ts: Date.now(),
-      ready: "ready",
-    });
+    while (true) {
+      // Callers are marked unready when there call finishes, and we need to remark them ready somehow.
+      // TODO: this isn't actually working.
+      await delay(callerReadyDelta());
+      this.#events.next({
+        kind: "change_ready_caller",
+        index,
+        ts: Date.now(),
+        ready: "ready",
+      });
+    }
 
     /*while (this.#running) {
       await delay(callerReadyDelta());
@@ -330,6 +335,9 @@ export class PhoneCanvassSimulator {
               const caller =
                 this.#callers[event.index] ??
                 fail(`Can't update caller that doesn't exist.`);
+              if (caller.ready == event.ready) {
+                break;
+              }
               caller.ready = event.ready;
               await this.phoneCanvassModel.updateOrCreateCaller(
                 caller.toUpdate(),

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassCall.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassCall.ts
@@ -113,7 +113,9 @@ export class Call {
     );
   }
 
-  async updateContactIfNeeded(entityManager: EntityManager): Promise<void> {
+  async updateContactEntityIfNeeded(
+    entityManager: EntityManager,
+  ): Promise<void> {
     const contact = await entityManager.findOneOrFail(
       PhoneCanvassContactEntity,
       {

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassCall.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassCall.ts
@@ -57,7 +57,7 @@ export class Call {
   static #currentId = 0;
 
   readonly state: Readonly<ImmutableCallState & UpdateableCallState>;
-  #updated = false;
+  updated = false;
   status: CallStatus;
 
   constructor(
@@ -164,12 +164,12 @@ export class Call {
   }
 
   update(status: CallStatus, props: Partial<UpdateableCallState>): Call {
-    if (this.#updated) {
+    if (this.updated) {
       throw new Error(
         `Calls should only be updated once. ${String(this.id)}, current status ${this.status}`,
       );
     }
-    this.#updated = true;
+    this.updated = true;
     if (callStatusSort(this.status, status) > 0) {
       throw new Error(
         `Call status can't go backwards from ${this.status} to ${status} (id ${String(this.id)}/${String(this.phoneCanvassContactId)})`,

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassMetricsTracker.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassMetricsTracker.ts
@@ -1,108 +1,133 @@
 import {
-  BehaviorSubject,
-  combineLatest,
   distinctUntilChanged,
   map,
   Observable,
   scan,
   shareReplay,
   startWith,
-  tap,
 } from "rxjs";
 import { Call } from "./PhoneCanvassCall.js";
 import { Injectable } from "@nestjs/common";
+import { CallAndCaller } from "../PhoneCanvass.model.js";
+import { PhoneCanvassCallerDTO } from "grassroots-shared/dtos/PhoneCanvass/PhoneCanvass.dto";
 
-export interface CallerCounts {
-  ready_no_caller: number;
-  ready_with_caller: number;
-  unready: number;
+interface CallCounts {
+  committed: number;
+  active: number;
+}
+
+export interface CallAndCallerCounts {
+  callers: {
+    ready_no_contact: number;
+    ready_with_contact: number;
+    unready: number;
+  };
+  calls: CallCounts;
 }
 
 @Injectable()
 export class PhoneCanvassMetricsTracker {
-  #callerCounts$ = new BehaviorSubject<CallerCounts>({
-    ready_no_caller: 0,
-    ready_with_caller: 0,
-    unready: 0,
-  });
-  #committedAndActiveCallCounts$: Observable<{
-    committed: number;
-    active: number;
-  }>;
+  #callAndCallerCounts$ = new Observable<CallAndCallerCounts>();
 
   readonly #idleCallerCount$: Observable<number>;
 
-  get callerCounts$(): Observable<CallerCounts> {
-    return this.#callerCounts$;
-  }
-
-  get committedAndActiveCallCounts(): Observable<{
-    committed: number;
-    active: number;
-  }> {
-    return this.#committedAndActiveCallCounts$;
+  get callAndCallerCounts$(): Observable<CallAndCallerCounts> {
+    return this.#callAndCallerCounts$;
   }
 
   get idleCallerCountObservable(): Observable<number> {
     return this.#idleCallerCount$;
   }
 
-  constructor(calls$: Observable<Call>) {
-    interface CommittedAndActiveCallCounts {
-      committed: Set<number>;
-      active: Set<number>;
-    }
-    this.#committedAndActiveCallCounts$ = calls$.pipe(
+  constructor(callsAndCallers$: Observable<CallAndCaller>) {
+    this.#callAndCallerCounts$ = callsAndCallers$.pipe(
       scan(
-        (
-          counts: CommittedAndActiveCallCounts,
-          call: Call,
-        ): CommittedAndActiveCallCounts => {
-          switch (call.status) {
-            case "NOT_STARTED":
-              counts.committed.add(call.id);
-              break;
-            case "IN_PROGRESS":
-              counts.active.add(call.id);
-              break;
-            case "COMPLETED":
-              counts.committed.delete(call.id);
-              counts.active.delete(call.id);
+        (acc, { caller, call }) => {
+          if (caller !== undefined) {
+            acc.callers.set(caller.id, caller);
+          }
+          if (call !== undefined) {
+            if (call.callerId !== undefined) {
+              acc.callsByCallerId.set(call.callerId, call);
+            }
+
+            switch (call.status) {
+              case "NOT_STARTED":
+                acc.callsByState.committed.add(call.id);
+                break;
+              case "IN_PROGRESS":
+                acc.callsByState.active.add(call.id);
+                break;
+              case "COMPLETED":
+                acc.callsByState.committed.delete(call.id);
+                acc.callsByState.active.delete(call.id);
+            }
           }
 
-          return counts;
+          return acc;
         },
-        { committed: new Set<number>(), active: new Set<number>() },
+        {
+          callsByCallerId: new Map<string, Call>(),
+          callers: new Map<string, PhoneCanvassCallerDTO>(),
+          callsByState: {
+            active: new Set<number>(),
+            committed: new Set<number>(),
+          },
+        },
       ),
-      map((sets) => {
-        return { committed: sets.committed.size, active: sets.active.size };
+      map(({ callsByCallerId, callers, callsByState }) => {
+        return [...callers.values()].reduce(
+          (acc: CallAndCallerCounts, caller: PhoneCanvassCallerDTO) => {
+            if (caller.ready === "unready") {
+              acc.callers.unready++;
+            } else {
+              const call = callsByCallerId.get(caller.id);
+              if (call === undefined) {
+                acc.callers.ready_no_contact++;
+              } else {
+                acc.callers.ready_with_contact++;
+              }
+            }
+            return acc;
+          },
+          {
+            callers: {
+              ready_no_contact: 0,
+              ready_with_contact: 0,
+              unready: 0,
+            },
+            // This is just passed through.
+            calls: {
+              committed: callsByState.committed.size,
+              active: callsByState.active.size,
+            },
+          } satisfies CallAndCallerCounts,
+        );
       }),
       distinctUntilChanged(),
-      tap((counts) => {
-        console.log("Call Counts", counts);
-      }),
-      startWith({ committed: 0, active: 0 }),
+      startWith({
+        callers: {
+          ready_no_contact: 0,
+          ready_with_contact: 0,
+          unready: 0,
+        },
+        // This is just passed through.
+        calls: {
+          committed: 0,
+          active: 0,
+        },
+      } satisfies CallAndCallerCounts),
       shareReplay({ bufferSize: 1, refCount: true }),
     );
 
-    this.#idleCallerCount$ = combineLatest([
-      this.#callerCounts$,
-      this.#committedAndActiveCallCounts$,
-    ]).pipe(
-      tap(([callerCounts, committedAndActiveCallCounts]) => {
-        console.log("BWA", { callerCounts, committedAndActiveCallCounts });
-      }),
+    this.#idleCallerCount$ = this.#callAndCallerCounts$.pipe(
       map(
-        ([callerCounts, committedAndActiveCallCounts]) =>
-          callerCounts.ready_no_caller +
-          callerCounts.ready_with_caller -
-          committedAndActiveCallCounts.committed,
+        ({ calls, callers }) =>
+          callers.ready_no_contact +
+          callers.ready_with_contact -
+          calls.committed,
       ),
       shareReplay({ bufferSize: 1, refCount: true }),
     );
-  }
-
-  onCallerCountUpdate(callerCounts: CallerCounts): void {
-    this.#callerCounts$.next(callerCounts);
   }
 }

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassModelFactory.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassModelFactory.ts
@@ -3,10 +3,9 @@ import { Injectable } from "@nestjs/common";
 import { PhoneCanvassContactEntity } from "../entities/PhoneCanvassContact.entity.js";
 import { PhoneCanvassMetricsTracker } from "./PhoneCanvassMetricsTracker.js";
 import { PhoneCanvassSchedulerImpl } from "./PhoneCanvassSchedulerImpl.js";
-import { ReplaySubject, Subject } from "rxjs";
-import { Call } from "./PhoneCanvassCall.js";
+import { filter, map, Observable, ReplaySubject } from "rxjs";
 import { TwilioService } from "../Twilio.service.js";
-import { PhoneCanvassModel } from "../PhoneCanvass.model.js";
+import { CallAndCaller, PhoneCanvassModel } from "../PhoneCanvass.model.js";
 import { PhoneCanvassCallersModel } from "../PhoneCanvassCallers.model.js";
 import { ServerMetaService } from "../../server-meta/ServerMeta.service.js";
 import { EntityManager } from "@mikro-orm/core";
@@ -14,9 +13,10 @@ import { PhoneCanvassCallerDTO } from "grassroots-shared/dtos/PhoneCanvass/Phone
 import { ExpectedFailureRateStrategy } from "./Strategies/ExpectedFailureRateStrategy.js";
 import { PhoneCanvassSchedulerStrategy } from "./Strategies/PhoneCanvassSchedulerStrategy.js";
 import { NoOvercallingStrategy } from "./Strategies/NoOvercallingStrategy.js";
+import { Call } from "./PhoneCanvassCall.js";
 
 interface ObservablesForTest {
-  callers$: Subject<Readonly<PhoneCanvassCallerDTO>>;
+  callers$: Observable<Readonly<PhoneCanvassCallerDTO>>;
 }
 
 let lastObservablesForTest: ObservablesForTest | undefined;
@@ -36,14 +36,27 @@ export class PhoneCanvassModelFactory {
     // Creating these observables here makes it a bit easier to reason about ownership.
     // None of these objects own them!
     // TODO: figure out how to clean these up when we're done with them...
-    const calls$ = new ReplaySubject<Call>(1);
-    const callers$ = new Subject<Readonly<PhoneCanvassCallerDTO>>();
+    const callsAndCallers$ = new ReplaySubject<CallAndCaller>(1);
+
+    const callers$ = callsAndCallers$.pipe(
+      map((x) => x.caller),
+      filter((x) => x !== undefined),
+    );
+
+    const calls$ = callsAndCallers$.pipe(
+      map((x) => x.call),
+      filter((x) => x !== undefined),
+    );
 
     lastObservablesForTest = {
       callers$,
     };
 
-    const metricsTracker = new PhoneCanvassMetricsTracker(calls$);
+    function emitCallAndCaller(callAndCaller: CallAndCaller): void {
+      callsAndCallers$.next(callAndCaller);
+    }
+
+    const metricsTracker = new PhoneCanvassMetricsTracker(callsAndCallers$);
     let strategy: PhoneCanvassSchedulerStrategy;
     if (params.strategyName === "no overcalling") {
       strategy = new NoOvercallingStrategy(metricsTracker);
@@ -60,7 +73,8 @@ export class PhoneCanvassModelFactory {
     const phoneCanvassCallersModel = new PhoneCanvassCallersModel({
       callers: callers$,
     });
-    return new PhoneCanvassModel({
+
+    const phoneCanvassModel = new PhoneCanvassModel({
       calls$,
       contacts: params.contacts,
       phoneCanvassId: params.phoneCanvassId,
@@ -69,7 +83,20 @@ export class PhoneCanvassModelFactory {
       phoneCanvassCallersModel,
       entityManager: params.entityManager,
       serverMetaService: params.serverMetaService,
+      emitCallAndCaller,
     });
+
+    phoneCanvassCallersModel.setEmitOnCallerUpdate(
+      (caller: PhoneCanvassCallerDTO) => {
+        phoneCanvassModel.emitOnCallerUpdate(caller);
+      },
+    );
+
+    scheduler.setEmitOnCallUpdate((call: Call) => {
+      phoneCanvassModel.emitOnCallUpdate(call);
+    });
+
+    return phoneCanvassModel;
   }
 }
 

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassModelFactory.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassModelFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import { PhoneCanvassContactEntity } from "../entities/PhoneCanvassContact.entity.js";
 import { PhoneCanvassMetricsTracker } from "./PhoneCanvassMetricsTracker.js";
 import { PhoneCanvassSchedulerImpl } from "./PhoneCanvassSchedulerImpl.js";
-import { filter, map, Observable, ReplaySubject } from "rxjs";
+import { filter, map, ReplaySubject } from "rxjs";
 import { TwilioService } from "../Twilio.service.js";
 import { CallAndCaller, PhoneCanvassModel } from "../PhoneCanvass.model.js";
 import { PhoneCanvassCallersModel } from "../PhoneCanvassCallers.model.js";
@@ -14,12 +14,6 @@ import { ExpectedFailureRateStrategy } from "./Strategies/ExpectedFailureRateStr
 import { PhoneCanvassSchedulerStrategy } from "./Strategies/PhoneCanvassSchedulerStrategy.js";
 import { NoOvercallingStrategy } from "./Strategies/NoOvercallingStrategy.js";
 import { Call } from "./PhoneCanvassCall.js";
-
-interface ObservablesForTest {
-  callers$: Observable<Readonly<PhoneCanvassCallerDTO>>;
-}
-
-let lastObservablesForTest: ObservablesForTest | undefined;
 
 type StrategyName = "no overcalling" | "expected failure rate";
 
@@ -48,10 +42,6 @@ export class PhoneCanvassModelFactory {
       filter((x) => x !== undefined),
     );
 
-    lastObservablesForTest = {
-      callers$,
-    };
-
     function emitCallAndCaller(callAndCaller: CallAndCaller): void {
       callsAndCallers$.next(callAndCaller);
     }
@@ -61,7 +51,8 @@ export class PhoneCanvassModelFactory {
     if (params.strategyName === "no overcalling") {
       strategy = new NoOvercallingStrategy(metricsTracker);
     } else {
-      strategy = new ExpectedFailureRateStrategy(metricsTracker, 0.75);
+      //strategy = new ExpectedFailureRateStrategy(metricsTracker, 0.75);
+      strategy = new ExpectedFailureRateStrategy(metricsTracker, 0.5);
     }
 
     const scheduler = new PhoneCanvassSchedulerImpl(strategy, metricsTracker, {
@@ -98,11 +89,4 @@ export class PhoneCanvassModelFactory {
 
     return phoneCanvassModel;
   }
-}
-
-export function getLastObservablesForTest(): ObservablesForTest {
-  if (lastObservablesForTest === undefined) {
-    throw new Error("getLastObservablesForTest called before createModel");
-  }
-  return lastObservablesForTest;
 }

--- a/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassSchedulerImpl.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/PhoneCanvassSchedulerImpl.ts
@@ -82,7 +82,6 @@ export class PhoneCanvassSchedulerImpl extends PhoneCanvassScheduler {
       next: (caller) => {
         switch (caller.ready) {
           case "ready": {
-            console.log("ADDING ", caller.id);
             this.pendingCallerSummariesById.set(caller.id, {
               id: caller.id,
               availabilityStartTime: this.#getCurrentTime(),
@@ -135,7 +134,6 @@ export class PhoneCanvassSchedulerImpl extends PhoneCanvassScheduler {
         : current;
     });
 
-    console.log("REMOVING ", oldestAvailableCaller.id);
     this.pendingCallerSummariesById.delete(oldestAvailableCaller.id);
 
     return oldestAvailableCaller.id;

--- a/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
@@ -1,4 +1,4 @@
-import { combineLatest, concatMap, filter, map, of, Subject, tap } from "rxjs";
+import { concatMap, filter, map, of, Subject, tap } from "rxjs";
 import { PhoneCanvassSchedulerStrategy } from "./PhoneCanvassSchedulerStrategy.js";
 import { PhoneCanvassMetricsTracker } from "../PhoneCanvassMetricsTracker.js";
 
@@ -13,27 +13,25 @@ export class ExpectedFailureRateStrategy extends PhoneCanvassSchedulerStrategy {
   ) {
     super(metricsTracker);
 
-    const callsToMake$ = combineLatest({
-      callerCounts: metricsTracker.callerCounts$,
-      committedAndActiveCallCounts: metricsTracker.committedAndActiveCallCounts,
-    }).pipe(
-      map(({ callerCounts, committedAndActiveCallCounts }) => {
-        console.log({ callerCounts, committedAndActiveCallCounts });
-        const currentCallsThatMightFail =
-          committedAndActiveCallCounts.committed -
-          committedAndActiveCallCounts.active;
+    const callsToMake$ = metricsTracker.callAndCallerCounts$.pipe(
+      map(({ calls, callers }) => {
+        const currentCallsThatMightFail = calls.committed - calls.active;
         if (currentCallsThatMightFail < 0) {
           throw new Error("Every committed call should also be active.");
         }
-        // TODO: we shouldn't distinguish between types of ready.
         const availableCallers =
-          callerCounts.ready_no_caller +
-          callerCounts.ready_with_caller -
-          committedAndActiveCallCounts.committed;
+          callers.ready_no_contact +
+          callers.ready_with_contact -
+          calls.committed;
         const targetCallsThatMightFail = Math.floor(
           availableCallers / expectedSuccessRate,
         );
-        console.log({ targetCallsThatMightFail, currentCallsThatMightFail });
+        console.log({
+          calls,
+          callers,
+          targetCallsThatMightFail,
+          currentCallsThatMightFail,
+        });
         return targetCallsThatMightFail - currentCallsThatMightFail;
       }),
     );

--- a/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
@@ -26,12 +26,6 @@ export class ExpectedFailureRateStrategy extends PhoneCanvassSchedulerStrategy {
         const targetCallsThatMightFail = Math.floor(
           availableCallers / expectedSuccessRate,
         );
-        console.log({
-          calls,
-          callers,
-          targetCallsThatMightFail,
-          currentCallsThatMightFail,
-        });
         return targetCallsThatMightFail - currentCallsThatMightFail;
       }),
     );
@@ -42,7 +36,6 @@ export class ExpectedFailureRateStrategy extends PhoneCanvassSchedulerStrategy {
         concatMap(() => {
           return of(undefined).pipe(
             tap(() => {
-              console.log("EMITTING");
               this.nextCall$.next(undefined);
             }),
           );

--- a/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/Strategies/ExpectedFailureRateStrategy.ts
@@ -14,19 +14,22 @@ export class ExpectedFailureRateStrategy extends PhoneCanvassSchedulerStrategy {
     super(metricsTracker);
 
     const callsToMake$ = combineLatest({
-      readyCallers: metricsTracker.readyCallerCount$,
+      callerCounts: metricsTracker.callerCounts$,
       committedAndActiveCallCounts: metricsTracker.committedAndActiveCallCounts,
     }).pipe(
-      map(({ readyCallers, committedAndActiveCallCounts }) => {
-        console.log({ readyCallers, committedAndActiveCallCounts });
+      map(({ callerCounts, committedAndActiveCallCounts }) => {
+        console.log({ callerCounts, committedAndActiveCallCounts });
         const currentCallsThatMightFail =
           committedAndActiveCallCounts.committed -
           committedAndActiveCallCounts.active;
         if (currentCallsThatMightFail < 0) {
           throw new Error("Every committed call should also be active.");
         }
+        // TODO: we shouldn't distinguish between types of ready.
         const availableCallers =
-          readyCallers - committedAndActiveCallCounts.active;
+          callerCounts.ready_no_caller +
+          callerCounts.ready_with_caller -
+          committedAndActiveCallCounts.committed;
         const targetCallsThatMightFail = Math.floor(
           availableCallers / expectedSuccessRate,
         );

--- a/grassroots-backend/src/phone-canvass/Scheduler/Strategies/NoOvercallingStrategy.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/Strategies/NoOvercallingStrategy.ts
@@ -1,4 +1,4 @@
-import { filter, map, Observable } from "rxjs";
+import { filter, map, Observable, tap } from "rxjs";
 import { PhoneCanvassSchedulerStrategy } from "./PhoneCanvassSchedulerStrategy.js";
 import { PhoneCanvassMetricsTracker } from "../PhoneCanvassMetricsTracker.js";
 
@@ -8,6 +8,9 @@ export class NoOvercallingStrategy extends PhoneCanvassSchedulerStrategy {
   constructor(metricsLogger: PhoneCanvassMetricsTracker) {
     super(metricsLogger);
     this.nextCall$ = metricsLogger.idleCallerCountObservable.pipe(
+      tap((idleCallerCount) => {
+        console.log("idleCallerCount", { idleCallerCount });
+      }),
       // Any time we have idle callers, emit once.
       // If there are multiple idle callers, this will get triggered
       // again, so idleCallerCount will trend to 0.

--- a/grassroots-backend/src/phone-canvass/Scheduler/Strategies/NoOvercallingStrategy.ts
+++ b/grassroots-backend/src/phone-canvass/Scheduler/Strategies/NoOvercallingStrategy.ts
@@ -1,4 +1,4 @@
-import { filter, map, Observable, tap } from "rxjs";
+import { filter, map, Observable } from "rxjs";
 import { PhoneCanvassSchedulerStrategy } from "./PhoneCanvassSchedulerStrategy.js";
 import { PhoneCanvassMetricsTracker } from "../PhoneCanvassMetricsTracker.js";
 
@@ -8,9 +8,6 @@ export class NoOvercallingStrategy extends PhoneCanvassSchedulerStrategy {
   constructor(metricsLogger: PhoneCanvassMetricsTracker) {
     super(metricsLogger);
     this.nextCall$ = metricsLogger.idleCallerCountObservable.pipe(
-      tap((idleCallerCount) => {
-        console.log("idleCallerCount", { idleCallerCount });
-      }),
       // Any time we have idle callers, emit once.
       // If there are multiple idle callers, this will get triggered
       // again, so idleCallerCount will trend to 0.

--- a/grassroots-backend/src/phone-canvass/Twilio.service.ts
+++ b/grassroots-backend/src/phone-canvass/Twilio.service.ts
@@ -45,9 +45,8 @@ export class TwilioService {
       String(call.phoneCanvassContactId),
     );
 
-    console.log("FIX BELOW!");
     const callInstance = await client.calls.create({
-      to: "2269892922", //call.state.contact.contact.phoneNumber,
+      to: call.state.contact.contact.phoneNumber,
       from: envVars.TWILIO_OUTGOING_NUMBER,
       record: true,
       statusCallback:

--- a/grassroots-backend/src/phone-canvass/Twilio.service.ts
+++ b/grassroots-backend/src/phone-canvass/Twilio.service.ts
@@ -45,8 +45,9 @@ export class TwilioService {
       String(call.phoneCanvassContactId),
     );
 
+    console.log("FIX BELOW!");
     const callInstance = await client.calls.create({
-      to: call.state.contact.contact.phoneNumber,
+      to: "2269892922", //call.state.contact.contact.phoneNumber,
       from: envVars.TWILIO_OUTGOING_NUMBER,
       record: true,
       statusCallback:

--- a/grassroots-frontend/src/Features/Contacts/Components/ContactCard.tsx
+++ b/grassroots-frontend/src/Features/Contacts/Components/ContactCard.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Button,
   Center,
+  List,
 } from "@mantine/core";
 import { PhoneCanvassContactDTO } from "grassroots-shared/dtos/PhoneCanvass/PhoneCanvass.dto";
 import { JSX } from "react";
@@ -91,6 +92,14 @@ export function ContactCard(props: ContactCardProps): JSX.Element {
     const tags: string[] = [
       phoneCanvassContact.getMetadataByKey("tags") ?? [],
     ].flat();
+
+    // TODO: This technically isn't true (for tags in particular) but it works for now.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const metadataJSON = JSON.parse(phoneCanvassContact.metadata) as [
+      string,
+      string,
+    ][];
+    const extraFields = metadataJSON.filter(([key]) => key !== "tags");
 
     mainCard = (
       <>
@@ -188,6 +197,24 @@ export function ContactCard(props: ContactCardProps): JSX.Element {
                 </Badge>
               ))}
             </Group>
+          </div>
+        )}
+
+        {extraFields.length > 0 && (
+          <div>
+            <Text size="sm" fw={600} tt="uppercase" c="dimmed" mt="lg">
+              Additional Information
+            </Text>
+            <List listStyleType="none">
+              {extraFields.map(([key, value], index) => (
+                <List.Item tt="none" key={index} variant="light">
+                  <Text component="span" fw={700} size="sm">{`${key}: `}</Text>
+                  <Text component="span" size="sm">
+                    {value}
+                  </Text>
+                </List.Item>
+              ))}
+            </List>
           </div>
         )}
       </>

--- a/grassroots-frontend/src/Features/Contacts/Components/ContactCard.tsx
+++ b/grassroots-frontend/src/Features/Contacts/Components/ContactCard.tsx
@@ -42,6 +42,22 @@ const getSupportLevelColor = (level: number | undefined): string => {
   return colors[level] ?? "grey";
 };
 
+const SUPPORT_LEVEL_TEXT: Record<number, string> = {
+  1: "Strong Opposition",
+  2: "Leaning Opposition",
+  3: "Undecided",
+  4: "Leaning Green",
+  5: "Strong Green",
+};
+
+const getSupportLevelText = (level: number | undefined): string => {
+  if (level === undefined || level < 1 || level > 5) {
+    return "Unknown Support";
+  }
+
+  return SUPPORT_LEVEL_TEXT[level] ?? "Unknown Support";
+};
+
 function getVotedColor(voter: string | undefined): string {
   switch (voter) {
     case "confirmed":
@@ -109,7 +125,7 @@ export function ContactCard(props: ContactCardProps): JSX.Element {
               size="lg"
               mb="xs"
             >
-              Support Level {contact.supportLevel}
+              {getSupportLevelText(contact.supportLevel)}
             </Badge>
             <Group gap="xs">
               <ThemeIcon

--- a/grassroots-frontend/src/Features/PhoneCanvass/Components/ManagePhoneCanvass.tsx
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Components/ManagePhoneCanvass.tsx
@@ -9,7 +9,8 @@ import {
 import { LinkButton } from "../../../Components/LinkButton.js";
 import { PaginatedContacts } from "../../Contacts/Components/PaginatedContacts.js";
 import { usePhoneCanvassContactList } from "../Logic/UsePhoneCanvassContactList.js";
-import { Group, Title } from "@mantine/core";
+import { Button, Group, Title } from "@mantine/core";
+import { useClipboard } from "@mantine/hooks";
 
 const ROWS_PER_PAGE = 10;
 
@@ -28,6 +29,8 @@ export function ManagePhoneCanvass(): JSX.Element {
       }),
     ).data ?? PaginatedPhoneCanvassContactResponseDTO.empty();
 
+  const clipboard = useClipboard({ timeout: 2000 });
+
   return (
     <>
       <Group>
@@ -39,6 +42,15 @@ export function ManagePhoneCanvass(): JSX.Element {
         >
           Participate
         </LinkButton>
+        <Button
+          onClick={() => {
+            clipboard.copy(
+              `${window.location.origin}/PhoneCanvass/${phoneCanvassId}`,
+            );
+          }}
+        >
+          {clipboard.copied ? "Copied!" : "Copy Link to Canvass"}
+        </Button>
       </Group>
       <PaginatedContacts
         paginatedContactResponse={PaginatedContactResponseDTO.from({

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/CallPartyStateStore.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/CallPartyStateStore.ts
@@ -13,7 +13,7 @@ const initialState = {
   serverInstanceUUID: undefined,
   totalContacts: 0,
   doneContacts: 0,
-  timestamp: 0,
+  generation: 0,
 } satisfies Partial<PhoneCanvassSyncData>;
 
 export function createCallPartyStateStore(): StoreApi<CallPartyStateStore> {

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
@@ -75,14 +75,11 @@ class SyncGroupManager {
     }
 
     if (this.#lastGeneration >= generation) {
-      console.log("THROWING OUT", data);
       // Avoid stale or repeated updates.
       return;
     }
 
     this.#lastGeneration = generation;
-
-    console.log(data);
 
     let caller = await getPhoneCanvassCaller({
       createOrUpdateCallerMutation: this.#createOrUpdateCallerMutation,

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
@@ -1,6 +1,7 @@
 import { SyncClient, SyncDocument } from "twilio-sync";
 import { CallPartyStateStore } from "./CallPartyStateStore.js";
 import {
+  CallReadyStatus,
   CreateOrUpdatePhoneCanvassCallerDTO,
   PhoneCanvassCallerDTO,
 } from "grassroots-shared/dtos/PhoneCanvass/PhoneCanvass.dto";
@@ -28,7 +29,7 @@ interface JoinSyncGroupParams {
   phoneCanvassCallerStore: PhoneCanvassCallerStore;
   createOrUpdateCallerMutation: CreateOrUpdateCallerMutation;
   onNewContact: (contact: ContactSummary | undefined) => void;
-  onReadyChanged: (ready: "ready" | "unready" | "last call") => void;
+  onReadyChanged: (ready: CallReadyStatus) => void;
 }
 
 // We don't give anyone a handle to the SyncGroup, so they can't hold onto a stale instance.
@@ -40,10 +41,10 @@ class SyncGroupManager {
   #phoneCanvassCallerStore: PhoneCanvassCallerStore;
   #createOrUpdateCallerMutation: CreateOrUpdateCallerMutation;
   #lastContact: ContactSummary | undefined;
-  #lastCallerReady: "ready" | "unready" | "last call" | undefined;
+  #lastCallerReady: CallReadyStatus | undefined;
   #lastTimestamp = 0;
   #onNewContact: (contact: ContactSummary | undefined) => void;
-  #onReadyChanged: (ready: "ready" | "unready" | "last call") => void;
+  #onReadyChanged: (ready: CallReadyStatus) => void;
 
   static instance: SyncGroupManager | undefined;
 

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/JoinTwilioSyncGroup.ts
@@ -42,7 +42,7 @@ class SyncGroupManager {
   #createOrUpdateCallerMutation: CreateOrUpdateCallerMutation;
   #lastContact: ContactSummary | undefined;
   #lastCallerReady: CallReadyStatus | undefined;
-  #lastTimestamp = 0;
+  #lastGeneration = 0;
   #onNewContact: (contact: ContactSummary | undefined) => void;
   #onReadyChanged: (ready: CallReadyStatus) => void;
 
@@ -61,7 +61,7 @@ class SyncGroupManager {
   }
 
   async #onUpdate(data: PhoneCanvassSyncData): Promise<void> {
-    const { timestamp } = data;
+    const { generation } = data;
     const callPartyStateStore = this.#callPartyStateStore.getState();
 
     if (
@@ -70,16 +70,19 @@ class SyncGroupManager {
     ) {
       // TODO: figure out why this keeps receiving onUpdates.
       // Has this gone away now that we prevent out of order messages?
-      this.#lastTimestamp = 0;
+      this.#lastGeneration = 0;
       return;
     }
 
-    if (this.#lastTimestamp >= timestamp) {
+    if (this.#lastGeneration >= generation) {
+      console.log("THROWING OUT", data);
       // Avoid stale or repeated updates.
       return;
     }
 
-    this.#lastTimestamp = timestamp;
+    this.#lastGeneration = generation;
+
+    console.log(data);
 
     let caller = await getPhoneCanvassCaller({
       createOrUpdateCallerMutation: this.#createOrUpdateCallerMutation,

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/MarkReadyForCalls.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/MarkReadyForCalls.ts
@@ -16,14 +16,6 @@ export interface UpdateReadyStateForCallsParams {
   createOrUpdateCallerMutation: CreateOrUpdateCallerMutation;
 }
 
-export async function markLastCall(
-  params: UpdateReadyStateForCallsParams,
-): Promise<void> {
-  const { caller } = params;
-  caller.ready = "last call";
-  await params.createOrUpdateCallerMutation(caller.toUpdate());
-}
-
 export async function markReadyForCalls(
   params: UpdateReadyStateForCallsParams,
 ): Promise<{ device: Device }> {

--- a/grassroots-frontend/src/Features/PhoneCanvass/Logic/UseCreateOrUpdateCaller.ts
+++ b/grassroots-frontend/src/Features/PhoneCanvass/Logic/UseCreateOrUpdateCaller.ts
@@ -13,7 +13,6 @@ import { PhoneCanvassCallerStore } from "./PhoneCanvassCallerStore.js";
 export interface UseCreateOrUpdateCallerParams {
   phoneCanvassId: string;
   phoneCanvassCallerStore: PhoneCanvassCallerStore;
-  keepAlive?: boolean;
 }
 
 export type CreateOrUpdateCallerMutation = UseMutateAsyncFunction<
@@ -32,7 +31,6 @@ export function useCreateOrUpdateCallerMutation(
       return PhoneCanvassCallerDTO.fromFetchOrThrow(
         await grassrootsAPI.POST("/phone-canvass/create-or-update-caller", {
           body: caller,
-          keepalive: params.keepAlive === true,
         }),
       );
     },

--- a/grassroots-shared/src/PhoneCanvass/PhoneCanvassSyncData.ts
+++ b/grassroots-shared/src/PhoneCanvass/PhoneCanvassSyncData.ts
@@ -22,5 +22,5 @@ export interface PhoneCanvassSyncData {
   phoneCanvassId: string;
   totalContacts: number;
   doneContacts: number;
-  timestamp: number;
+  generation: number;
 }

--- a/grassroots-shared/src/PhoneCanvass/PhoneCanvassSyncData.ts
+++ b/grassroots-shared/src/PhoneCanvass/PhoneCanvassSyncData.ts
@@ -1,4 +1,5 @@
 import { CallResult, CallStatus } from "../dtos/PhoneCanvass/CallStatus.dto.js";
+import { CallReadyStatus } from "../dtos/PhoneCanvass/PhoneCanvass.dto.js";
 
 export interface ContactSummary {
   contactDisplayName: string;
@@ -10,7 +11,7 @@ export interface ContactSummary {
 
 export interface CallerSummary {
   callerId: string;
-  ready: "ready" | "unready" | "last call";
+  ready: CallReadyStatus;
   displayName: string;
 }
 

--- a/grassroots-shared/src/dtos/PhoneCanvass/PhoneCanvass.dto.ts
+++ b/grassroots-shared/src/dtos/PhoneCanvass/PhoneCanvass.dto.ts
@@ -245,8 +245,9 @@ export class PhoneCanvassCallIdentifierDTO extends createDTOBase(
 enum ReadyEnum {
   unready = "unready",
   ready = "ready",
-  lastCall = "last call",
 }
+
+export type CallReadyStatus = `${ReadyEnum}`;
 
 // (displayName, activePhoneCanvassId) is globally unique.
 export class CreateOrUpdatePhoneCanvassCallerDTO extends createDTOBase(
@@ -273,7 +274,7 @@ export class CreateOrUpdatePhoneCanvassCallerDTO extends createDTOBase(
   @IsEnum(ReadyEnum)
   @IsOptional()
   @ApiPropertyOptional({ enum: ReadyEnum })
-  ready?: "ready" | "unready" | "last call";
+  ready?: CallReadyStatus;
 }
 
 // (displayName, activePhoneCanvassId) is globally unique.
@@ -305,7 +306,7 @@ export class PhoneCanvassCallerDTO extends createDTOBase("PhoneCanvassCaller") {
 
   @IsEnum(ReadyEnum)
   @ApiProperty({ enum: ReadyEnum })
-  ready!: "ready" | "unready" | "last call";
+  ready!: CallReadyStatus;
 
   toUpdate(): CreateOrUpdatePhoneCanvassCallerDTO {
     return CreateOrUpdatePhoneCanvassCallerDTO.from(propsOf(this));


### PR DESCRIPTION
The most substantive change here is getting rid of the last call button, and addressing some bugs.
This involved combining the observables for calls and callers, to avoid races in responding to a completed call.