### PR TITLE
Add Trivy copyleft license scanning to CI

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # MEDIUM blocks as well as HIGH and CRITICAL: Trivy's built-in classifier
+      # files any copyleft licence missing from trivy.yaml under `reciprocal`,
+      # which is MEDIUM. Gating only on HIGH would let unlisted copyleft pass.
       - name: Scan dependencies for copyleft licenses
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -34,7 +37,7 @@ jobs:
           scan-ref: .
           scanners: license
           trivy-config: trivy.yaml
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL
           exit-code: 1
           format: table
 

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,0 +1,51 @@
+name: "License Scan"
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Licences change under us on republish, so re-scan even when nothing merges.
+    - cron: "0 13 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-license:
+    name: Copyleft License Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js & pnpm
+        uses: pnpm/action-setup@v4
+
+      # Lockfiles carry no licence metadata. Trivy reads the `license` field from
+      # each installed package.json, so the tree has to be on disk to be scanned.
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Scan dependencies for copyleft licenses
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: license
+          trivy-config: trivy.yaml
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          format: table
+
+      - name: Report full license inventory
+        if: always()
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: license
+          trivy-config: trivy.yaml
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          exit-code: 0
+          format: table

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -2,6 +2,7 @@ name: "License Scan"
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install
 
       - name: Scan dependencies for copyleft licenses
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -40,7 +40,7 @@ jobs:
 
       - name: Report full license inventory
         if: always()
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,6 +1,10 @@
 scan:
   scanners:
     - license
+  skip-files:
+    # Our own licence. Without this, full-file inspection classifies the project
+    # under its own policy and fails the build on this repo's AGPL-3.0 grant.
+    - LICENSE
 
 license:
   # File-header inspection. Catches packages that ship a LICENSE file but leave

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,57 @@
+scan:
+  scanners:
+    - license
+
+license:
+  # File-header inspection. Catches packages that ship a LICENSE file but leave
+  # the `license` field out of package.json, at the cost of a slower scan.
+  full: true
+  confidenceLevel: 0.9
+
+  # CRITICAL. Network-copyleft and source-available licences, which can impose
+  # obligations on a hosted service, not just on distributed binaries.
+  forbidden:
+    - AGPL-1.0
+    - AGPL-3.0
+    - AGPL-3.0-only
+    - AGPL-3.0-or-later
+    - SSPL-1.0
+    - BUSL-1.1
+    - CC-BY-NC-1.0
+    - CC-BY-NC-2.0
+    - CC-BY-NC-2.5
+    - CC-BY-NC-3.0
+    - CC-BY-NC-4.0
+    - CC-BY-NC-SA-4.0
+
+  # HIGH. Strong and weak copyleft. LGPL is included because dynamic-linking
+  # relief is murky for bundled JavaScript.
+  restricted:
+    - GPL-2.0
+    - GPL-2.0-only
+    - GPL-2.0-or-later
+    - GPL-3.0
+    - GPL-3.0-only
+    - GPL-3.0-or-later
+    - LGPL-2.0
+    - LGPL-2.1
+    - LGPL-2.1-only
+    - LGPL-2.1-or-later
+    - LGPL-3.0
+    - LGPL-3.0-only
+    - LGPL-3.0-or-later
+    - OSL-3.0
+    - EUPL-1.1
+    - EUPL-1.2
+
+  # MEDIUM. File-level copyleft. Reported but does not fail CI, since these are
+  # generally safe to depend on without relicensing our own code.
+  reciprocal:
+    - MPL-1.1
+    - MPL-2.0
+    - EPL-1.0
+    - EPL-2.0
+    - CDDL-1.0
+    - CDDL-1.1
+
+  ignored: []

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,3 +1,12 @@
+# Licence policy for a dual-licensed project.
+#
+# Grassroots ships under AGPL-3.0 and under a separate commercial licence. The
+# commercial grant is the binding constraint: we can only offer proprietary
+# terms on code we are free to relicense. A copyleft dependency cannot be
+# relicensed, so it forecloses the commercial track no matter how permissive it
+# would be for a purely AGPL project. Every form of copyleft blocks here,
+# including the file-level kind that is normally considered safe to link.
+
 scan:
   scanners:
     - license
@@ -12,8 +21,8 @@ license:
   full: true
   confidenceLevel: 0.9
 
-  # CRITICAL. Network-copyleft and source-available licences, which can impose
-  # obligations on a hosted service, not just on distributed binaries.
+  # CRITICAL. Network copyleft, source-available, and non-commercial terms.
+  # These are incompatible with a commercial grant on their face.
   forbidden:
     - AGPL-1.0
     - AGPL-3.0
@@ -21,16 +30,23 @@ license:
     - AGPL-3.0-or-later
     - SSPL-1.0
     - BUSL-1.1
+    - CPAL-1.0
+    - RPL-1.5
     - CC-BY-NC-1.0
     - CC-BY-NC-2.0
     - CC-BY-NC-2.5
     - CC-BY-NC-3.0
     - CC-BY-NC-4.0
+    - CC-BY-NC-SA-3.0
     - CC-BY-NC-SA-4.0
+    - CC-BY-SA-4.0
 
-  # HIGH. Strong and weak copyleft. LGPL is included because dynamic-linking
-  # relief is murky for bundled JavaScript.
+  # HIGH. Strong copyleft, weak copyleft, and file-level copyleft alike. MPL,
+  # EPL, and CDDL sit here rather than under `reciprocal` because their
+  # per-file source obligation survives relicensing, which is precisely what
+  # the commercial grant cannot accommodate.
   restricted:
+    - GPL-1.0
     - GPL-2.0
     - GPL-2.0-only
     - GPL-2.0-or-later
@@ -44,18 +60,25 @@ license:
     - LGPL-3.0
     - LGPL-3.0-only
     - LGPL-3.0-or-later
-    - OSL-3.0
-    - EUPL-1.1
-    - EUPL-1.2
-
-  # MEDIUM. File-level copyleft. Reported but does not fail CI, since these are
-  # generally safe to depend on without relicensing our own code.
-  reciprocal:
+    - MPL-1.0
     - MPL-1.1
     - MPL-2.0
     - EPL-1.0
     - EPL-2.0
     - CDDL-1.0
     - CDDL-1.1
+    - OSL-1.0
+    - OSL-2.0
+    - OSL-3.0
+    - EUPL-1.0
+    - EUPL-1.1
+    - EUPL-1.2
+    - CECILL-2.1
+    - QPL-1.0
+    - IPL-1.0
+    - Sleepycat
+    - GFDL-1.1-only
+    - GFDL-1.2-only
+    - GFDL-1.3-only
 
   ignored: []


### PR DESCRIPTION
## What

Adds a `License Scan` workflow that uses [Trivy](https://trivy.dev) to fail CI when a dependency introduces a copyleft licence.

Two new files:

- `trivy.yaml` — the licence policy, kept separate from the workflow so it is reviewable and portable to other repos.
- `.github/workflows/license-scan.yml` — runs on PRs, on pushes to `main`, and weekly.

## Why every form of copyleft blocks

Grassroots is dual licensed: AGPL-3.0 plus a separate commercial grant. The commercial grant is the binding constraint, because we can only offer proprietary terms on code we are free to relicense.

This makes the policy stricter than it would be for a purely AGPL project. Under AGPL alone, GPL and LGPL dependencies are compatible and pose no problem. Under dual licensing they foreclose the commercial track, so they are blocked here. The same reasoning extends to file-level copyleft: MPL, EPL, and CDDL are normally safe to link against, but their per-file source obligation survives relicensing, which is exactly what the commercial grant cannot accommodate.

| Category | Severity | Fails CI | Examples |
|---|---|---|---|
| `forbidden` | CRITICAL | Yes | AGPL, SSPL, BUSL, CPAL, RPL, CC-BY-NC, CC-BY-SA |
| `restricted` | HIGH | Yes | GPL, LGPL, MPL, EPL, CDDL, OSL, EUPL, CECILL, QPL, GFDL |

The gate fails on `MEDIUM` as well as `HIGH` and `CRITICAL`. Trivy's built-in classifier files any copyleft licence absent from `trivy.yaml` under `reciprocal`, which is MEDIUM, so gating only on HIGH would let unlisted copyleft through.

## Results

The scan passes against the current tree. The dependency inventory is entirely MIT, ISC, BSD-2-Clause, BSD-3-Clause, Apache-2.0, 0BSD, and `(MIT OR CC0-1.0)`. No copyleft dependency is present today, so this change locks in the status quo rather than forcing any removals.

## Implementation notes

- **`pnpm install` runs before the scan.** `pnpm-lock.yaml` carries no licence metadata. Trivy reads the `license` field from each installed `package.json`, so the dependency tree has to be on disk or the scan finds almost nothing.
- **The repo's own `LICENSE` is skipped.** With `license.full: true`, file inspection classified this project's own AGPL-3.0 grant as a forbidden licence and failed the build on it.
- **A second, non-failing step prints the full licence inventory**, so the build log shows every dependency's licence rather than only violations.

## Follow-ups not included here

- `UNKNOWN` licences are not gated. A package with no declared licence is "all rights reserved" by default and is redistributable under neither grant, so this is a genuine exposure, but gating it immediately would likely be noisy enough to block every PR. Worth auditing the inventory output first.
- The root `package.json` declares `"license": "AGPLv3"`, which is not a valid SPDX identifier (`AGPL-3.0-or-later` is). The four workspace packages declare `UNLICENSED`, which contradicts the root grant. These fields are what downstream tooling reads.
- `license.full: true` makes the scan slower and can surface false positives from vendored licence text. Worth turning off if the job gets noisy.
- The `Lint, Build, Format and Auto-Commit changes` check is failing on this PR for an unrelated, pre-existing reason: `secrets.ACTION_PAT` is unset or expired, so `actions/checkout` falls back to prompting for credentials. It has failed on every branch since April 2026 and needs a rotated PAT.
